### PR TITLE
collection: fix ArrayCollection sort by DateTime

### DIFF
--- a/src/Collection/Helpers/ArrayCollectionHelper.php
+++ b/src/Collection/Helpers/ArrayCollectionHelper.php
@@ -173,10 +173,8 @@ class ArrayCollectionHelper
 
 		return function ($a, $b) use ($getter, $columns) {
 			foreach ($columns as $pair) {
-				$_a = $getter($a, $pair[0], $pair[2]);
-				$_a = $_a instanceof IEntity ? $_a->getValue('id') : $_a;
-				$_b = $getter($b, $pair[0], $pair[2]);
-				$_b = $_b instanceof IEntity ? $_b->getValue('id') : $_b;
+				$_a = $this->simplifyValue($getter, $a, $pair);
+				$_b = $this->simplifyValue($getter, $b, $pair);
 				$direction = $pair[1] === ICollection::ASC ? 1 : -1;
 
 				if (is_int($_a) || is_float($_a)) {
@@ -197,6 +195,19 @@ class ArrayCollectionHelper
 
 			return 0;
 		};
+	}
+
+	private function simplifyValue($getter, $raw, array $pair)
+	{
+		$value = $getter($raw, $pair[0], $pair[2]);
+		if ($value instanceof IEntity) {
+			return $value->getValue('id');
+
+		} elseif ($value instanceof \DateTime) {
+			return $value->format('%U.%u');
+		}
+
+		return $value;
 	}
 
 }

--- a/tests/cases/unit/Collection/ArrayCollectionTest.phpt
+++ b/tests/cases/unit/Collection/ArrayCollectionTest.phpt
@@ -77,6 +77,10 @@ class ArrayCollectionTest extends TestCase
 			iterator_to_array($collection->orderBy('this->name', ICollection::DESC))
 		);
 		Assert::same(
+			[$authors[0], $authors[2], $authors[1]],
+			iterator_to_array($collection->orderBy('this->born', ICollection::DESC))
+		);
+		Assert::same(
 			[$authors[2], $authors[1], $authors[0]],
 			iterator_to_array($collection->orderBy('this->age', ICollection::DESC)->orderBy('this->name'))
 		);
@@ -143,7 +147,7 @@ class ArrayCollectionTest extends TestCase
 		$authors = [
 			$this->e('NextrasTests\Orm\Author', ['name' => 'Jon', 'born' => '2012-01-01']),
 			$this->e('NextrasTests\Orm\Author', ['name' => 'Sansa', 'born' => '2011-01-01']),
-			$this->e('NextrasTests\Orm\Author', ['name' => 'Eddard', 'born' => '2011-01-01']),
+			$this->e('NextrasTests\Orm\Author', ['name' => 'Eddard', 'born' => '2011-06-01']),
 		];
 
 		$books = [


### PR DESCRIPTION
Fixes
> E_RECOVERABLE_ERROR: Object of class DateTime could not be converted to string

when calling `collection->get()->orderBy('createdAt')`