### PR TITLE
reflection: add support for datetime immutable

### DIFF
--- a/src/Entity/Reflection/PropertyMetadata.php
+++ b/src/Entity/Reflection/PropertyMetadata.php
@@ -140,16 +140,38 @@ class PropertyMetadata extends Object
 
 		foreach ($this->types as $type => $foo) {
 			if ($type === 'datetime') {
-				if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
+				if ($value instanceof \DateTime) {
 					return TRUE;
-				}
 
-				if (is_string($value) && $value !== '') {
+				} elseif ($value instanceof \DateTimeImmutable) {
+					$value = new \DateTime($value->format('c'));
+					return TRUE;
+
+				} elseif (is_string($value) && $value !== '') {
 					$value = new \DateTime($value);
 					$value->setTimezone(new DateTimeZone(date_default_timezone_get()));
 					return TRUE;
+
 				} elseif (ctype_digit($value)) {
 					$value = new \DateTime("@{$value}");
+					return TRUE;
+				}
+
+			} elseif ($type === 'datetimeimmutable') {
+				if ($value instanceof \DateTimeImmutable) {
+					return TRUE;
+
+				} elseif ($value instanceof \DateTime) {
+					$value = new \DateTimeImmutable($value->format('c'));
+					return TRUE;
+
+				} elseif (is_string($value) && $value !== '') {
+					$tmp = new \DateTimeImmutable($value);
+					$value = $tmp->setTimezone(new DateTimeZone(date_default_timezone_get()));
+					return TRUE;
+
+				} elseif (ctype_digit($value)) {
+					$value = new \DateTimeImmutable("@{$value}");
 					return TRUE;
 				}
 

--- a/tests/cases/integration/Repository/repository.callbacks.phpt
+++ b/tests/cases/integration/Repository/repository.callbacks.phpt
@@ -48,13 +48,13 @@ class RepositoryCallbacksTest extends DataTestCase
 	{
 		$allFlush = [];
 		$this->orm->onFlush[] = function(array $persisted, array $removed) use (&$allFlush) {
-			foreach ($persisted as $persitedE) $allFlush[] = $persitedE;
+			foreach ($persisted as $persistedE) $allFlush[] = $persistedE;
 			foreach ($removed as $removedE) $allFlush[] = $removedE;
 		};
 
 		$booksFlush = [];
 		$this->orm->books->onFlush[] = function(array $persisted, array $removed) use (&$booksFlush) {
-			foreach ($persisted as $persitedE) $booksFlush[] = $persitedE;
+			foreach ($persisted as $persistedE) $booksFlush[] = $persistedE;
 			foreach ($removed as $removedE) $booksFlush[] = $removedE;
 		};
 

--- a/tests/inc/model/book/Book.php
+++ b/tests/inc/model/book/Book.php
@@ -2,7 +2,7 @@
 
 namespace NextrasTests\Orm;
 
-use DateTime;
+use DateTimeImmutable;
 use Nextras\Orm\Entity\Entity;
 use Nextras\Orm\Relationships\ManyHasMany as MHM;
 
@@ -16,7 +16,7 @@ use Nextras\Orm\Relationships\ManyHasMany as MHM;
  * @property Book|NULL          $previousPart  {1:1d Book::$nextPart}
  * @property Ean|NULL           $ean           {1:1d Ean::$book, primary=true}
  * @property Publisher          $publisher     {m:1 Publisher::$books}
- * @property DateTime           $publishedAt   {default now}
+ * @property DateTimeImmutable  $publishedAt   {default now}
  */
 final class Book extends Entity
 {


### PR DESCRIPTION
There are multiple places in app where using Immutable is good idea, for example `createdAt` etc.

Similar functionality can already be achieved with `DateTime` and custom getters; this patch adds some complexity, so feel free to reject this, I won't be too salty about it. Also, I should include like 5 more test cases.

There was however an issue that allowed setting property of time `DateTime` to `DateTimeImmutable`, which definitely a bug. This patch fixes that by typecasting between mutable and immutable as defined by property metadata.