### PR TITLE
tests: add failing DateTime with tz case

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/inc/Helper.php';
 
 define('TEMP_DIR', __DIR__ . '/tmp');
 date_default_timezone_set('Europe/Prague');
+//date_default_timezone_set('+03:00');
 
 Environment::setup();
 Helper::check();

--- a/tests/cases/integration/Repository/repository.identitymap.phpt
+++ b/tests/cases/integration/Repository/repository.identitymap.phpt
@@ -8,9 +8,11 @@
 namespace NextrasTests\Orm\Integration\Repository;
 
 use Mockery;
+use Nextras\Orm\Model\IModel;
 use NextrasTests\Orm\Author;
 use NextrasTests\Orm\Book;
 use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Publisher;
 use Tester\Assert;
 
 $dic = require_once __DIR__ . '/../../../bootstrap.php';
@@ -34,6 +36,23 @@ class RepositoryIdentityMapTest extends DataTestCase
 		$this->orm->authors->persistAndFlush($author);
 
 		Assert::same($author->books->get()->fetch(), $book);
+	}
+
+	public function testCreateEntity()
+	{
+		$bookA = new Book();
+		$bookA->title = 'B';
+		$bookA->author = new Author();
+		$bookA->author->name = 'A';
+		$bookA->publisher = new Publisher();
+		$bookA->publisher->name = 'P';
+
+		$this->orm->books->persistAndFlush($bookA);
+		$id = $bookA->getPersistedId();
+		$this->orm->clearIdentityMapAndCaches(IModel::I_KNOW_WHAT_I_AM_DOING);
+
+		$bookB = $this->orm->books->getById($id);
+		Assert::same($bookA->createdAt->format('c'), $bookB->createdAt->format('c'));
 	}
 
 }

--- a/tests/cases/integration/Repository/repository.identitymap.phpt
+++ b/tests/cases/integration/Repository/repository.identitymap.phpt
@@ -47,12 +47,17 @@ class RepositoryIdentityMapTest extends DataTestCase
 		$bookA->publisher = new Publisher();
 		$bookA->publisher->name = 'P';
 
+		$bookA->createdAt = new \DateTime('2015-01-01 12:01+02:00');
+		$bookA->createdAt->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+		Assert::same('2015-01-01T11:01:00+01:00', $bookA->createdAt->format('c'));
 		$this->orm->books->persistAndFlush($bookA);
 		$id = $bookA->getPersistedId();
+		$exp = $bookA->createdAt->format('c');
+
 		$this->orm->clearIdentityMapAndCaches(IModel::I_KNOW_WHAT_I_AM_DOING);
 
 		$bookB = $this->orm->books->getById($id);
-		Assert::same($bookA->createdAt->format('c'), $bookB->createdAt->format('c'));
+		Assert::same($exp, $bookB->createdAt->format('c'));
 	}
 
 }

--- a/tests/db/mysql-init.sql
+++ b/tests/db/mysql-init.sql
@@ -28,6 +28,7 @@ CREATE TABLE eans (
 
 CREATE TABLE books (
 	id int NOT NULL AUTO_INCREMENT,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	author_id int NOT NULL,
 	translator_id int,
 	title varchar(50) NOT NULL,

--- a/tests/db/pgsql-init.sql
+++ b/tests/db/pgsql-init.sql
@@ -28,6 +28,7 @@ CREATE TABLE "eans" (
 
 CREATE TABLE "books" (
 	"id" SERIAL4 NOT NULL,
+	"created_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	"author_id" int NOT NULL,
 	"translator_id" int,
 	"title" varchar(50) NOT NULL,

--- a/tests/inc/model/book/Book.php
+++ b/tests/inc/model/book/Book.php
@@ -2,20 +2,23 @@
 
 namespace NextrasTests\Orm;
 
+use DateTime;
 use Nextras\Orm\Entity\Entity;
 use Nextras\Orm\Relationships\ManyHasMany as MHM;
 
 
 /**
- * @property string       $title
- * @property Author       $author        {m:1 Author}
- * @property Author|NULL  $translator    {m:1 Author::$translatedBooks}
- * @property MHM|Tag[]    $tags          {m:n Tag primary}
- * @property Book|NULL    $nextPart      {1:1d Book::$previousPart primary}
- * @property Book|NULL    $previousPart  {1:1d Book::$nextPart}
- * @property Ean|NULL     $ean           {1:1d Ean primary}
- * @property Publisher    $publisher     {m:1 PublishersRepository}
+ * @property string             $title
+ * @property DateTime           $createdAt     {default now}
+ * @property Author             $author        {m:1 Author}
+ * @property Author|NULL        $translator    {m:1 Author::$translatedBooks}
+ * @property MHM|Tag[]          $tags          {m:n Tag primary}
+ * @property Book|NULL          $nextPart      {1:1d Book::$previousPart primary}
+ * @property Book|NULL          $previousPart  {1:1d Book::$nextPart}
+ * @property Ean|NULL           $ean           {1:1d Ean primary}
+ * @property Publisher          $publisher     {m:1 PublishersRepository}
  */
 final class Book extends Entity
 {
+
 }


### PR DESCRIPTION
If php timezone is not UTC, entity loaded from database contains both the default timezone *and* datetime shifted by the timezone.

> `2015-09-09T13:21:19+02:00` should be `2015-09-09T11:21:19+02:00`

This happens with postgresql's timestamp without time zone.

Expected behaviour: save `2015-09-09T13:21:19+02:00` as `2015-09-09T09:21:19+00:00`, load as  `2015-09-09T09:21:19+00:00` and apply php timezone, which will result to original  `2015-09-09T11:21:19+02:00`