### PR TITLE
Collection: getIteratorCount using ORDER BY fix

### DIFF
--- a/src/Mapper/Dbal/DbalCollection.php
+++ b/src/Mapper/Dbal/DbalCollection.php
@@ -239,6 +239,7 @@ class DbalCollection implements ICollection
 			} else {
 				$builder = clone $this->queryBuilder;
 				$builder->select('COUNT(*)');
+				$builder->orderBy(NULL);
 				$sql = $builder->getQuerySql();
 				$args = $builder->getQueryParameters();
 			}


### PR DESCRIPTION
 > ERROR: column "blog_post.id" must appear in the GROUP BY clause or be used in an aggregate function

```sql
SELECT COUNT(*) FROM "blog_post" AS "blog_post" ORDER BY "blog_post".id
```