### PR TITLE
entity: fix setReadOnlyValue on IPropertyContainer

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -126,7 +126,16 @@ abstract class AbstractEntity implements IEntity
 	public function setReadOnlyValue($name, $value)
 	{
 		$metadata = $this->metadata->getProperty($name);
-		$this->internalSetValue($metadata, $name, $value);
+
+		// temporarily disable readOnly flag, internalSetValue() calls setValue
+		$readOnly = $metadata->isReadonly;
+		$metadata->isReadonly = FALSE;
+		try {
+			$this->internalSetValue($metadata, $name, $value);
+		} finally {
+			$metadata->isReadonly = $readOnly;
+		}
+
 		return $this;
 	}
 

--- a/tests/cases/integration/Entity/entity.setReadOnlyValue().phpt
+++ b/tests/cases/integration/Entity/entity.setReadOnlyValue().phpt
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @testCase
+ * @dataProvider ../../../sections.ini
+ */
+
+namespace NextrasTests\Orm\Integration\Entity;
+
+use Mockery;
+use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Ean;
+use NextrasTests\Orm\TagFollower;
+use Tester\Assert;
+
+$dic = require_once __DIR__ . '/../../../bootstrap.php';
+
+
+class EntitySetReadOnlyValueTest extends DataTestCase
+{
+
+	public function testWithIPropertyContainer()
+	{
+		$tagA = $this->orm->tags->getById(1);
+		$tagB = $this->orm->tags->getById(2);
+
+		$follower = new TagFollower();
+		$follower->tag = $tagA;
+
+		$follower->getMetadata()->getProperty('tag')->isReadonly = TRUE;
+
+		$follower->setReadOnlyValue('tag', $tagB);
+
+		Assert::same($tagB, $follower->tag);
+	}
+
+}
+
+
+$test = new EntitySetReadOnlyValueTest($dic);
+$test->run();


### PR DESCRIPTION
- `setReadOnlyValue` internally calls
- `internalSetValue` which in turn may call
- `setValue`, which has `isReadOnly` check

credit goes to @JanTvrdik for this solution