### PR TITLE
collection: fix findBy null missing operator

### DIFF
--- a/src/Mapper/Dbal/QueryBuilderHelper.php
+++ b/src/Mapper/Dbal/QueryBuilderHelper.php
@@ -175,8 +175,8 @@ class QueryBuilderHelper extends Object
 			$converted = $sourceReflection->convertEntityToStorage([$column => $value]);
 			$column = key($converted);
 			if (($pos = strpos($column, '%')) !== FALSE) {
-				$column = substr($column, 0, $pos);
 				$modifier = substr($column, $pos);
+				$column = substr($column, 0, $pos);
 			}
 			$value = current($converted);
 			return "[{$sourceAlias}.{$column}]";

--- a/tests/cases/integration/Collection/collection.phpt
+++ b/tests/cases/integration/Collection/collection.phpt
@@ -167,6 +167,14 @@ class CollectionTest extends DataTestCase
 		Assert::same(2, $tags->countStored());
 		Assert::same('Tag 1', $tags->fetch()->name);
 	}
+
+
+	public function testFindByNull()
+	{
+		$all = $this->orm->books->findBy(['printedAt' => NULL])->fetchAll();
+		Assert::count(4, $all);
+	}
+
 }
 
 

--- a/tests/db/mysql-init.sql
+++ b/tests/db/mysql-init.sql
@@ -35,6 +35,7 @@ CREATE TABLE books (
 	next_part int,
 	publisher_id int NOT NULL,
 	published_at DATETIME NOT NULL,
+	printed_at DATETIME,
 	ean_id int,
 	PRIMARY KEY (id),
 	CONSTRAINT books_authors FOREIGN KEY (author_id) REFERENCES authors (id),

--- a/tests/db/pgsql-init.sql
+++ b/tests/db/pgsql-init.sql
@@ -35,6 +35,7 @@ CREATE TABLE "books" (
 	"next_part" int,
 	"publisher_id" int NOT NULL,
 	"published_at" TIMESTAMP NOT NULL,
+	"printed_at" TIMESTAMP,
 	"ean_id" int,
 	PRIMARY KEY ("id"),
 	CONSTRAINT "books_authors" FOREIGN KEY ("author_id") REFERENCES authors ("id"),

--- a/tests/inc/model/book/Book.php
+++ b/tests/inc/model/book/Book.php
@@ -2,6 +2,7 @@
 
 namespace NextrasTests\Orm;
 
+use DateTime;
 use DateTimeImmutable;
 use Nextras\Orm\Entity\Entity;
 use Nextras\Orm\Relationships\ManyHasMany as MHM;
@@ -18,6 +19,7 @@ use Nextras\Orm\Relationships\ManyHasMany as MHM;
  * @property Ean|NULL           $ean           {1:1d Ean::$book, primary=true}
  * @property Publisher          $publisher     {m:1 Publisher::$books}
  * @property DateTimeImmutable  $publishedAt   {default now}
+ * @property NULL|DateTime      $printedAt
  */
 final class Book extends Entity
 {


### PR DESCRIPTION
was causing
> Nextras\Dbal\InvalidArgumentException: Redundant query parameter or missing modifier in query fragment 'SELECT [books.*] FROM [books] AS [books] WHERE [books.printed_at] IS '.

and also
> Nextras\Dbal\InvalidArgumentException: Modifier %column expects value to be string, NULL given.
