### PR TITLE
Minor patches: getValue interface, entity creator

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -148,6 +148,11 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	/**
+	 * Returns value.
+	 * @param  string   $name
+	 * @return mixed
+	 */
 	public function & getValue($name)
 	{
 		$property = $this->metadata->getProperty($name);

--- a/src/Entity/IEntity.php
+++ b/src/Entity/IEntity.php
@@ -96,7 +96,7 @@ interface IEntity extends Serializable
 	 * @param  string   $name
 	 * @return mixed
 	 */
-	public function getValue($name);
+	public function & getValue($name);
 
 
 	/**

--- a/src/TestHelper/EntityCreator.php
+++ b/src/TestHelper/EntityCreator.php
@@ -56,7 +56,7 @@ class EntityCreator
 				$value = $this->random($property);
 			}
 
-			$entity->setValue($key, $value);
+			$entity->setReadOnlyValue($key, $value);
 		}
 	}
 


### PR DESCRIPTION
getValue

> This change is a fix strictly for recent releases of PhpStorm. Php does
not count pass-by-reference as method declaration and implementations
are free to differ. PhpStorm highlights all entities as incompatible
with the interface though.