### PR TITLE
Add memory leak test

### DIFF
--- a/src/TestHelper/TestMapper.php
+++ b/src/TestHelper/TestMapper.php
@@ -15,7 +15,7 @@ use Nextras\Orm\Mapper\Memory\ArrayMapper;
 class TestMapper extends ArrayMapper
 {
 	/** @var array */
-	protected $storage = [];
+	protected $storage = '';
 
 	/** @var mixed[] array of callbacks */
 	protected $methods = [];
@@ -39,12 +39,13 @@ class TestMapper extends ArrayMapper
 
 	protected function readData()
 	{
-		return $this->storage;
+		return unserialize($this->storage);
 	}
 
 
 	protected function saveData(array $data)
 	{
-		$this->storage = $data;
+		$this->storage = serialize($data);
 	}
+
 }

--- a/tests/cases/acceptance/MemoryManagementTest.phpt
+++ b/tests/cases/acceptance/MemoryManagementTest.phpt
@@ -1,0 +1,52 @@
+<?php
+
+namespace NextrasTests\Orm\Collection;
+
+use Mockery;
+use Nextras\Orm\Model\IModel;
+use NextrasTests\Orm\Author;
+use NextrasTests\Orm\TestCase;
+use Tester\Assert;
+
+$dic = require_once __DIR__ . '/../../bootstrap.php';
+
+
+/**
+ * @testCase
+ * @dataProvider ../../sections.ini
+ */
+class MemoryManagementTest extends TestCase
+{
+
+	private function persistEntity()
+	{
+		$entity = new Author();
+		$entity->name = 'Foobar';
+		$this->orm->authors->persistAndFlush($entity);
+	}
+
+
+	public function testMemoryLeak()
+	{
+		$this->persistEntity();
+		$this->orm->clearIdentityMapAndCaches(IModel::I_KNOW_WHAT_I_AM_DOING);
+
+		$baseline = memory_get_usage(FALSE);
+
+		for ($i = 0; $i < 200; ++$i) {
+			$this->persistEntity();
+			$this->orm->clearIdentityMapAndCaches(IModel::I_KNOW_WHAT_I_AM_DOING);
+
+			if (memory_get_usage(FALSE) > $baseline * 1.05) {
+				Assert::fail("Memory leak detected");
+			}
+		}
+
+		Assert::true((bool) 'no leak detected');
+	}
+
+}
+
+
+$test = new MemoryManagementTest($dic);
+$test->run();


### PR DESCRIPTION
Long running daemons and workers often call `$orm->clearIdentityMapAndCaches()` in hopes to reduce memory footprint. This test case makes sure the memory usage is roughly constant.