### PR TITLE
persistence: added new tests for relationships with indirect cycles

### DIFF
--- a/tests/cases/integration/Relationships/relationships.cyclic.phpt
+++ b/tests/cases/integration/Relationships/relationships.cyclic.phpt
@@ -9,9 +9,13 @@ namespace NextrasTests\Orm\Integration\Relationships;
 
 use Mockery;
 use Nextras\Orm\InvalidStateException;
+use Nextras\Orm\Model\IModel;
+use NextrasTests\Orm\Author;
+use NextrasTests\Orm\Book;
 use NextrasTests\Orm\DataTestCase;
 use NextrasTests\Orm\Photo;
 use NextrasTests\Orm\PhotoAlbum;
+use NextrasTests\Orm\Publisher;
 use Tester\Assert;
 
 $dic = require_once __DIR__ . '/../../../bootstrap.php';
@@ -19,6 +23,33 @@ $dic = require_once __DIR__ . '/../../../bootstrap.php';
 
 class RelationshipCyclicTest extends DataTestCase
 {
+	public function testNotCycle()
+	{
+		$publisher = new Publisher();
+		$publisher->name = 'Jupiter Mining Corporation';
+
+		$author = new Author();
+		$author->name = 'Arnold Judas Rimmer';
+
+		$translator = new Author();
+		$translator->name = 'Dave Lister';
+		$translator->favoredBy->add($author);
+
+		$book = new Book();
+		$book->title = 'Better Than Life';
+		$book->publisher = $publisher;
+		$book->author = $author;
+		$book->translator = $translator;
+
+		$this->orm->persist($author);
+
+		Assert::true($publisher->isPersisted());
+		Assert::true($author->isPersisted());
+		Assert::true($translator->isPersisted());
+		Assert::true($book->isPersisted());
+	}
+
+
 	public function testCycleCheck()
 	{
 		$album = new PhotoAlbum();

--- a/tests/cases/unit/Repository/PersistenceHelperTest.phpt
+++ b/tests/cases/unit/Repository/PersistenceHelperTest.phpt
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+namespace NextrasTests\Orm\Repository;
+
+use Mockery;
+use Nextras\Orm\Repository\PersistenceHelper;
+use NextrasTests\Orm\Author;
+use NextrasTests\Orm\Book;
+use NextrasTests\Orm\Publisher;
+use NextrasTests\Orm\TestCase;
+use Tester\Assert;
+
+$dic = require_once __DIR__ . '/../../../bootstrap.php';
+
+
+class PersistenceHelperTest extends TestCase
+{
+
+	public function testNotCycle()
+	{
+		$publisher = new Publisher();
+		$publisher->name = 'Jupiter Mining Corporation';
+
+		$author = new Author();
+		$author->name = 'Arnold Judas Rimmer';
+
+		$translator = new Author();
+		$translator->name = 'Dave Lister';
+		$translator->favoredBy->add($author);
+
+		$book = new Book();
+		$book->title = 'Better Than Life';
+		$book->publisher = $publisher;
+		$book->author = $author;
+		$book->translator = $translator;
+
+		Assert::same(
+			[
+				$translator, $author,
+				$translator->favoredBy,
+				$translator->books,
+				$publisher, $book, $translator->translatedBooks,
+				$translator->tagFollowers,
+				$author->favoredBy,
+				$author->books,
+				$author->translatedBooks,
+				$author->tagFollowers,
+				$book->tags,
+				$publisher->books,
+			],
+			array_values(PersistenceHelper::getCascadeQueue($author, $this->orm, true))
+		);
+
+		Assert::same(
+			[
+				$translator,
+				$author, $translator->favoredBy,
+				$translator->books,
+				$publisher, $book, $translator->translatedBooks,
+				$translator->tagFollowers,
+				$author->favoredBy,
+				$author->books,
+				$author->translatedBooks,
+				$author->tagFollowers,
+				$book->tags,
+				$publisher->books,
+			],
+			array_values(PersistenceHelper::getCascadeQueue($translator, $this->orm, true))
+		);
+
+		Assert::same(
+			[
+				$translator, $author, $publisher, $book,
+				$translator->favoredBy,
+				$translator->books,
+				$translator->translatedBooks,
+				$translator->tagFollowers,
+				$author->favoredBy,
+				$author->books,
+				$author->translatedBooks,
+				$author->tagFollowers,
+				$book->tags,
+				$publisher->books,
+			],
+			array_values(PersistenceHelper::getCascadeQueue($book, $this->orm, true))
+		);
+
+
+		Assert::same(
+			[
+				$publisher,
+				$translator, $author, $book, $publisher->books,
+				$translator->favoredBy,
+				$translator->books,
+				$translator->translatedBooks,
+				$translator->tagFollowers,
+				$author->favoredBy,
+				$author->books,
+				$author->translatedBooks,
+				$author->tagFollowers,
+				$book->tags,
+			],
+			array_values(PersistenceHelper::getCascadeQueue($publisher, $this->orm, true))
+		);
+	}
+
+}
+
+
+$test = new PersistenceHelperTest($dic);
+$test->run();

--- a/tests/db/mysql-init.sql
+++ b/tests/db/mysql-init.sql
@@ -3,7 +3,9 @@ CREATE TABLE authors (
 	name varchar(50) NOT NULL,
 	web varchar(100) NOT NULL,
 	born date DEFAULT NULL,
-	PRIMARY KEY(id)
+	favorite_author_id int,
+	PRIMARY KEY(id),
+	CONSTRAINT authors_favorite_author FOREIGN KEY (favorite_author_id) REFERENCES authors (id)
 ) AUTO_INCREMENT=2;
 
 

--- a/tests/db/pgsql-init.sql
+++ b/tests/db/pgsql-init.sql
@@ -3,7 +3,9 @@ CREATE TABLE "authors" (
 	"name" varchar(50) NOT NULL,
 	"web" varchar(100) NOT NULL,
 	"born" date DEFAULT NULL,
-	PRIMARY KEY("id")
+	"favorite_author_id" int,
+	PRIMARY KEY("id"),
+	CONSTRAINT "authors_favorite_author" FOREIGN KEY ("favorite_author_id") REFERENCES authors ("id")
 );
 
 

--- a/tests/inc/model/author/Author.php
+++ b/tests/inc/model/author/Author.php
@@ -12,6 +12,8 @@ use Nextras\Orm\Relationships\OneHasMany as OHM;
  * @property string             $name
  * @property DateTime|NULL      $born {default now}
  * @property string             $web {default "http://www.example.com"}
+ * @property Author|null        $favoriteAuthor {m:1 Author::$favoredBy}
+ * @property OHM|Author[]       $favoredBy {1:m Author::$favoriteAuthor}
  * @property OHM|Book[]         $books {1:m Book::$author, orderBy=[id, DESC], cascade=[persist, remove]}
  * @property OHM|Book[]         $translatedBooks {1:m Book::$translator}
  * @property OHM|TagFollower[]  $tagFollowers {1:m TagFollower::$author, cascade=[persist, remove]}


### PR DESCRIPTION
After a bit more drawing this is what I came up with as the best approximation of what the previous algorithm failed to handle properly. It fails when starting from the top node.

![dependency diagram](https://cloud.githubusercontent.com/assets/175109/13722880/fc2df4e0-e853-11e5-92de-7961bf3987a3.png)
