### PR TITLE
Broken repeated persistence of relationships due to invalid isLoaded state

### DIFF
--- a/src/Relationships/HasMany.php
+++ b/src/Relationships/HasMany.php
@@ -45,6 +45,9 @@ abstract class HasMany extends Object implements IRelationshipCollection
 	/** @var bool */
 	protected $isModified = false;
 
+	/** @var bool */
+	protected $wasLoaded = false;
+
 	/** @var IRelationshipMapper */
 	protected $relationshipMapper;
 
@@ -188,7 +191,7 @@ abstract class HasMany extends Object implements IRelationshipCollection
 
 	public function isLoaded()
 	{
-		return !($this->collection === null && empty($this->toAdd) && empty($this->toRemove));
+		return $this->wasLoaded || $this->collection !== null || !empty($this->toAdd) || !empty($this->toRemove);
 	}
 
 

--- a/src/Relationships/ManyHasMany.php
+++ b/src/Relationships/ManyHasMany.php
@@ -19,8 +19,8 @@ class ManyHasMany extends HasMany
 		foreach ($this->toAdd as $entity) {
 			$entities[] = $entity;
 		}
-		if ($this->collection) {
-			foreach ($this->collection as $entity) {
+		if ($this->collection || $this->wasLoaded) {
+			foreach ($this->getIterator() as $entity) {
 				$entities[] = $entity;
 			}
 		}
@@ -44,6 +44,7 @@ class ManyHasMany extends HasMany
 		$this->toAdd = [];
 		$this->toRemove = [];
 		$this->isModified = false;
+		$this->wasLoaded = true;
 		$this->collection = null;
 
 		if ($this->metadata->relationship->isMain) {

--- a/src/Relationships/OneHasMany.php
+++ b/src/Relationships/OneHasMany.php
@@ -24,7 +24,7 @@ class OneHasMany extends HasMany
 				$entities[] = $remove;
 			}
 		}
-		if ($this->collection !== null) {
+		if ($this->collection !== null || $this->wasLoaded) {
 			foreach ($this->getIterator() as $entity) {
 				$entities[] = $entity;
 			}
@@ -37,8 +37,9 @@ class OneHasMany extends HasMany
 	{
 		$this->toAdd = [];
 		$this->toRemove = [];
-		$this->collection = null;
+		$this->wasLoaded = true;
 		$this->isModified = false;
+		$this->collection = null;
 	}
 
 

--- a/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
@@ -143,6 +143,26 @@ class RelationshipManyHasManyTest extends DataTestCase
 		Assert::same(0, $tags->count());
 	}
 
+
+	public function testRepeatedPersisting()
+	{
+		$tagA = new Tag('A');
+		$tagB = new Tag('B');
+
+		$book = $this->orm->books->getById(1);
+		$book->tags->add($tagA);
+		$book->tags->add($tagB);
+
+		$this->orm->persistAndFlush($book);
+		Assert::false($tagA->isModified());
+		Assert::false($tagB->isModified());
+
+		$tagA->name = 'X';
+		$this->orm->persistAndFlush($book);
+		Assert::false($tagA->isModified());
+		Assert::false($tagB->isModified());
+	}
+
 }
 
 

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.isLoaded().phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.isLoaded().phpt
@@ -29,7 +29,7 @@ class RelationshipsOneHasManyIsLoadedTest extends TestCase
 		$this->orm->authors->flush();
 
 		foreach ($this->orm->authors->findAll() as $author) {
-			Assert::false($author->books->isLoaded());
+			Assert::true($author->books->isLoaded());
 		}
 
 		foreach ($this->orm->authors->findAll() as $author) {

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.persistence.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.persistence.phpt
@@ -10,6 +10,7 @@ use Mockery;
 use NextrasTests\Orm\Author;
 use NextrasTests\Orm\Book;
 use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Publisher;
 use Tester\Assert;
 
 $dic = require_once __DIR__ . '/../../../bootstrap.php';
@@ -42,7 +43,28 @@ class RelationshipsOneHasManyPersistenceTest extends DataTestCase
 		foreach ($books as $book) {
 			Assert::false($book->isModified());
 		}
+	}
 
+
+	public function testRepeatedPersisting()
+	{
+		$publisher = new Publisher();
+		$publisher->name = 'Jupiter Mining Corporation';
+
+		$author = new Author();
+		$author->name = 'Arnold Judas Rimmer';
+
+		$book = new Book();
+		$book->title = 'Better Than Life';
+		$book->publisher = $publisher;
+		$book->author = $author;
+
+		$this->orm->persistAndFlush($author);
+		Assert::false($book->isModified());
+
+		$book->title = 'Backwards';
+		$this->orm->persistAndFlush($author);
+		Assert::false($book->isModified());
 	}
 
 }


### PR DESCRIPTION
Caused by:

* https://github.com/nextras/orm/blob/cffc101fefce0b9ad258a5c4a8ac1ca2886d4a9c/src/Repository/PersistenceHelper.php#L112-L114
* https://github.com/nextras/orm/blob/cffc101fefce0b9ad258a5c4a8ac1ca2886d4a9c/src/Relationships/OneHasMany.php#L36-L42
* https://github.com/nextras/orm/blob/cffc101fefce0b9ad258a5c4a8ac1ca2886d4a9c/src/Relationships/HasMany.php#L189-L192
