### PR TITLE
failing test case

### DIFF
--- a/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
@@ -12,6 +12,7 @@ use Nextras\Orm\Collection\ICollection;
 use NextrasTests\Orm\Book;
 use NextrasTests\Orm\DataTestCase;
 use NextrasTests\Orm\Tag;
+use NextrasTests\Orm\User;
 use Tester\Assert;
 
 $dic = require_once __DIR__ . '/../../../bootstrap.php';
@@ -158,6 +159,11 @@ class RelationshipManyHasManyTest extends DataTestCase
 
 		Assert::true($book->tags->isModified());
 		Assert::true($tag->books->isModified());
+	}
+	
+	public function testSelfReferencing() {
+		$user = new User();
+		$this->orm->persistAndFlush($user);
 	}
 
 

--- a/tests/db/mysql-init.sql
+++ b/tests/db/mysql-init.sql
@@ -85,6 +85,19 @@ CREATE TABLE book_collections (
 	PRIMARY KEY (`id`)
 );
 
+CREATE TABLE user (
+	id int NOT NULL AUTO_INCREMENT,
+	PRIMARY KEY(id)
+) AUTO_INCREMENT=1;
+
+CREATE TABLE user_x_user (
+	my_friends_id int NOT NULL,
+	friends_with_me_id int NOT NULL,
+	PRIMARY KEY (my_friends_id, friends_with_me_id),
+	CONSTRAINT my_friends_key FOREIGN KEY (my_friends_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT friends_with_me_key FOREIGN KEY (friends_with_me_id) REFERENCES user (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
 CREATE TRIGGER `book_collections_bu_trigger` BEFORE UPDATE ON `book_collections`
 FOR EACH ROW SET NEW.updated_at = NOW();
 

--- a/tests/inc/model/Model.php
+++ b/tests/inc/model/Model.php
@@ -17,6 +17,7 @@ use Nextras\Orm\Model\Model as OrmModel;
  * @property-read PublishersRepository $publishers
  * @property-read TagsRepository $tags
  * @property-read TagFollowersRepository $tagFollowers
+ * @property-read UserRepository $user
  */
 class Model extends OrmModel
 {

--- a/tests/inc/model/user/User.php
+++ b/tests/inc/model/user/User.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace NextrasTests\Orm;
+
+use Nextras\Orm\Entity\Entity;
+use Nextras\Orm\Relationships\ManyHasMany as MHM;
+
+/**
+ * @property int                 $id             {primary}
+ * @property ManyHasMany|User[]  $myFriends      {m:m User::$friendsWithMe, isMain=true}
+ * @property ManyHasMany|User[]  $friendsWithMe  {m:m User::$myFriends}
+ */
+final class User extends Entity
+{
+}

--- a/tests/inc/model/user/UserMapper.php
+++ b/tests/inc/model/user/UserMapper.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NextrasTests\Orm;
+
+use Nextras\Orm\Mapper\Mapper;
+
+
+final class UserMapper extends Mapper
+{
+}

--- a/tests/inc/model/user/UserRepository.php
+++ b/tests/inc/model/user/UserRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NextrasTests\Orm;
+
+use Nextras\Orm\Repository\Repository;
+
+
+/**
+ * @method User|NULL getById($id)
+ * @method User|NULL getByName($name)
+ */
+final class UserRepository extends Repository
+{
+	static function getEntityClassNames()
+	{
+		return [User::class];
+	}
+}


### PR DESCRIPTION
ManyToMany self-referencing relationship is not working for us (based on example at https://nextras.org/orm/docs/2.1/relationships#toc-m-m-self-referencing ).

Getting the `"No primary keys detected for many has many '{$joinTable}' join table."` exception probably because the condition at https://github.com/nextras/orm/blob/master/src/Mapper/Dbal/StorageReflection/StorageReflection.php#L250 never gets to the else branch, the table name being the same for both source and target.