### PR TITLE
mapper: impl autoupdate by default to allow any PK

### DIFF
--- a/src/Mapper/Dbal/DbalMapper.php
+++ b/src/Mapper/Dbal/DbalMapper.php
@@ -26,7 +26,7 @@ use Nextras\Orm\Mapper\IRelationshipMapper;
 use Nextras\Orm\StorageReflection\IStorageReflection;
 
 
-class DbalMapper extends BaseMapper
+class DbalMapper extends BaseMapper implements IPersistAutoupdateMapper
 {
 	/** @var Connection */
 	protected $connection;
@@ -245,7 +245,7 @@ class DbalMapper extends BaseMapper
 
 	public function getAutoupdateReselectExpression(): array
 	{
-		return ['%column[]', ['*']];
+		return ['%column[]', $this->getStorageReflection()->getStoragePrimaryKey()];
 	}
 
 


### PR DESCRIPTION
Original implementation does not support any other primary key (OK)
than those based on sequence. See

   `Nextras\Dbal\Drivers\Pgsql\PgsqlDriver::getLastInsertedId()`

This is problematic when using other data types such as UUID,
which currently throws rather cryptic exception:

  PgsqlDriver require to pass sequence name for `getLastInsertedId()` method.

This patch bypasses calling of this method, because autoupdate will
populate the PK columns and thus

  `Nextras\Orm\Mapper\Dbal\DbalMapper::persist(IEntity $entity)`

will use the `$entity->getValue('id')` branch.

This patch is not backwards compatible. Implementors of
IPersistAutoupdateMapper might rely on the original implementation
of returning all columns.

I have not taken into consideration performance degradation on MySQL
platform, which emulates the autoupdate.