### PR TITLE
Pr/fix many to many count stored

### DIFF
--- a/src/Mapper/Dbal/DbalCollection.php
+++ b/src/Mapper/Dbal/DbalCollection.php
@@ -262,22 +262,15 @@ class DbalCollection implements ICollection
 	{
 		if ($this->resultCount === null) {
 			$builder = clone $this->queryBuilder;
-			if ($builder->hasLimitOffsetClause()) {
-				/** @var StorageReflection $reflection */
-				$reflection = $this->mapper->getStorageReflection();
-				$primary = $reflection->getStoragePrimaryKey();
-				foreach ($primary as $column) {
-					$builder->addSelect('%table.%column', $builder->getFromAlias(), $column);
-				}
-				$sql = 'SELECT COUNT(*) AS count FROM (' . $builder->getQuerySql() . ') temp';
-				$args = $builder->getQueryParameters();
 
-			} else {
-				$builder->select('COUNT(*) AS count');
-				$builder->orderBy(null);
-				$sql = $builder->getQuerySql();
-				$args = $builder->getQueryParameters();
+			/** @var StorageReflection $reflection */
+			$reflection = $this->mapper->getStorageReflection();
+			$primary = $reflection->getStoragePrimaryKey();
+			foreach ($primary as $column) {
+				$builder->addSelect('%table.%column', $builder->getFromAlias(), $column);
 			}
+			$sql = 'SELECT COUNT(*) AS count FROM (' . $builder->getQuerySql() . ') temp';
+			$args = $builder->getQueryParameters();
 
 			$this->resultCount = $this->connection->queryArgs($sql, $args)->fetchField();
 		}

--- a/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
@@ -245,6 +245,13 @@ class RelationshipManyHasManyTest extends DataTestCase
 		$pairs = $connection->query('SELECT author_id FROM tag_followers WHERE tag_id = 2 ORDER BY author_id')->fetchPairs(null, 'author_id');
 		Assert::same([1, 2], $pairs);
 	}
+
+
+	public function testCountStoredOnManyToManyCondition()
+	{
+		$books = $this->orm->books->findBy(['this->tags->name' => 'Tag 2']);
+		Assert::same(2, $books->countStored());
+	}
 }
 
 


### PR DESCRIPTION
Replacing SELECT  columns with COUNT(*) does not work the way as intended if the query contains a GROUP BY. This is used by the ORM itself in DbalCollection::findBy() when filtering through m:n relationships. Using a subquery for counting the results should always work fine.