### PR TITLE
update adding select into query builder instead of replacing existing

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -246,7 +246,7 @@ abstract class AbstractEntity implements IEntity
 	public function onLoad(array $data)
 	{
 		foreach ($this->metadata->getProperties() as $name => $metadataProperty) {
-			if (isset($data[$name])) {
+			if (!$metadataProperty->isVirtual && isset($data[$name])) {
 				$this->data[$name] = $data[$name];
 			}
 		}

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -246,7 +246,7 @@ abstract class AbstractEntity implements IEntity
 	public function onLoad(array $data)
 	{
 		foreach ($this->metadata->getProperties() as $name => $metadataProperty) {
-			if (!$metadataProperty->isVirtual && isset($data[$name])) {
+			if (isset($data[$name])) {
 				$this->data[$name] = $data[$name];
 			}
 		}

--- a/src/Mapper/Dbal/DbalCollection.php
+++ b/src/Mapper/Dbal/DbalCollection.php
@@ -294,7 +294,7 @@ class DbalCollection implements ICollection
 		$builder = clone $this->queryBuilder;
 
 		$table = $builder->getFromAlias();
-		$builder->select("[$table.*]");
+		$builder->addSelect("[$table.*]");
 
 		$result = $this->connection->queryArgs(
 			$builder->getQuerySql(),


### PR DESCRIPTION
Case i use custom method in ORM mapper.

```
$builder = $this->builder->from('[table]', 'alias')->addSelect('`secondaryTable`.*);
return $this->toCollection($builder);
```

Current implementation of execute() function in Mapper\DbalCollection will overwrite whole select.