### PR TITLE
Loading annotation from traits too

### DIFF
--- a/tests/inc/model/CreatedColumnTrait.php
+++ b/tests/inc/model/CreatedColumnTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NextrasTests\Orm;
+
+use DateTimeImmutable;
+
+/**
+ * @property DateTimeImmutable    $createdAt             {default now}
+ * @property-read string          $createdAtFormatted    {virtual}
+ */
+trait CreatedColumnTrait {
+
+    /**
+     * Getter for column createdAtFormatted
+     * @return string
+     */
+    protected function getterCreatedAtFormatted() : string {
+        return $this->createdAt->format('d.m.Y H:i:s');
+    }
+}

--- a/tests/inc/model/tagFollower/TagFollower.php
+++ b/tests/inc/model/tagFollower/TagFollower.php
@@ -2,7 +2,6 @@
 
 namespace NextrasTests\Orm;
 
-use DateTimeImmutable;
 use Nextras\Orm\Entity\Entity;
 
 
@@ -10,8 +9,8 @@ use Nextras\Orm\Entity\Entity;
  * @property array             $id        {primary-proxy}
  * @property Author            $author    {m:1 Author::$tagFollowers} {primary}
  * @property Tag               $tag       {m:1 Tag::$tagFollowers} {primary}
- * @property DateTimeImmutable $createdAt {default now}
  */
 final class TagFollower extends Entity
 {
+    use CreatedColumnTrait;
 }


### PR DESCRIPTION
Just idea to load annotation for Entity from traits too. Example can be using TimestatemableTrait with `created...` or `update...` columns, next can be `cancelled...` etc...

First load trait, then entity class for overrides. Methods are loaded from original class with `use ***trait`.