### PR TITLE
Improved error message for oneSided property

### DIFF
--- a/src/Entity/Reflection/MetadataParser.php
+++ b/src/Entity/Reflection/MetadataParser.php
@@ -349,6 +349,10 @@ class MetadataParser implements IMetadataParser
 		} else {
 			$targetProperty = substr($class, $pos + 3); // skip ::$
 			$class = substr($class, 0, $pos);
+
+			if (isset($args['oneSided'])) {
+				throw new InvalidModifierDefinitionException("Relationship {{$modifier}} in {$this->currentReflection->name}::\${$property->name} has set oneSided property but it also specifies target property \${$targetProperty}.");
+			}
 		}
 
 		$entity = Reflection::expandClassName($class, $this->currentReflection);


### PR DESCRIPTION
I started with classical bidirectional relation. 
```php
/**
 * @property int     $id          {primary}
 * @property Author  $author      {m:1 Author::$id}
 */
class Book extends Nextras\Orm\Entity\Entity
{}
```

Because I did a mistake (in reality, i wanted one-sided relation and i had also mistake in property) so I got exception `Book::$author has not defined a symmetric relationship in Author::$id.`

So i added oneSided property and **forgot to delete** atribute in target.
```php
/**
 * @property int     $id          {primary}
 * @property Author  $author      {m:1 Author::$id, oneSided=true}
 */
class Book extends Nextras\Orm\Entity\Entity
{}
```

As a result I got this exception `Modifier {m:1} in Book::$author property has unknown arguments: oneSided.`

This was really confusing because oneSided should be known for `{m:1}` modifier. So I dug into the code, debug it step by step and found out that it looks for `::` string. At that time I knew where I did the mistake.

I think that this improved error message can help those who will be switching from bidirectional to one-sided relationships and, same as me, forget to remove target atribute.