### PR TITLE
Revert "bridge/nette: recastring service name to string as it may be …

### DIFF
--- a/src/Bridges/NetteDI/DIRepositoryFinder.php
+++ b/src/Bridges/NetteDI/DIRepositoryFinder.php
@@ -41,7 +41,6 @@ class DIRepositoryFinder implements IRepositoryFinder
 		$repositories = [];
 		$repositoriesMap = [];
 		foreach ($types as $serviceName => $serviceDefinition) {
-			$serviceName = (string) $serviceName;
 			if ($serviceDefinition instanceof \Nette\DI\Definitions\FactoryDefinition) {
 				$serviceDefinition
 					->getResultDefinition()


### PR DESCRIPTION
…a numeric-string [closes #333]"

This reverts commit f649a71b74f8b87cee2e81873be65f8675114684.

Casting is not needed anymore, because of latest changes in nette/di which changed the way how the services name type is treated - it will always be string.