### PR TITLE
collection: deprecate 'this->' for traversion, use '::' for STI class…

### DIFF
--- a/doc/collection.texy
+++ b/doc/collection.texy
@@ -39,14 +39,14 @@ $books = $orm->books->findBy([
 
 Allowed operators are `=`, `!=`, `<=`, `<`, `>=` and `>`.
 
-You can filter the collection using conditions using entity relationships. To filter collection by a relationship, use a *traversing expression*: it consists of the path delimited by `->` - an arrow. You have to start the expression by referencing the starting point using `this` keyword.
+You can filter the collection using conditions using entity relationships. To filter collection by a relationship, use a *traversing expression*: it consists of the path delimited by `->` - the same arrow you use in PHP.
 
 /--php
 // find all books which were authored by Jon Snow
-$orm->books->findBy(['this->author->name' => 'Jon Snow']);
+$orm->books->findBy(['author->name' => 'Jon Snow']);
 
 // find all books which were not translated by Jon Snow
-$orm->books->findBy(['this->translator->name!=' => 'Jon Snow']);
+$orm->books->findBy(['translator->name!=' => 'Jon Snow']);
 \--
 
 The described syntax may be expanded to support a `OR` logical conjunction. Unshift the operator `ICollection::OR` as a first value of the query array:

--- a/doc/embeddables.texy
+++ b/doc/embeddables.texy
@@ -42,7 +42,7 @@ class Address extends Nextras\Orm\Entity\Embeddable
 The example by default store data in `address_street` column, etc. You may also filter by the nested structure. This works for both array and dbal collection.
 
 /--php
-$users = $orm->users->findBy(['this->address->city' => 'Prague']);
+$users = $orm->users->findBy(['address->city' => 'Prague']);
 \--
 
 Setting value require creating new embeddable instance by yourself. If you want change its property, create a new one and set it again.

--- a/doc/entity-sti.texy
+++ b/doc/entity-sti.texy
@@ -51,12 +51,12 @@ class AddressesRepository extends Nextras\Orm\Repository\Repository
 Usage
 =====
 
-Collection calls will by default return a mixed result - with both types. You may filter these collection by the common properties defined on the abstract class. If you want to filter by property that is not shared between all entities, it's your responsibility to filter the proper entities fist. To access not shared properties, prepend a class name into the expression path.
+Collection calls will by default return a mixed result - with both types. You may filter these collection by the common properties defined on the abstract class. If you want to filter by property that is not shared between all entities, it's your responsibility to filter the proper entities fist. To access non-shared properties, prepend a class name with double colon into the expression path.
 
 /--php
 $orm->addresses->findBy([
 	'type' => Address::TYPE_PUBLIC,
-	'Address->maintainer->id' => $maintainerId,
+	'Address::maintainer->id' => $maintainerId,
 ]);
 \--
 

--- a/doc/repository.texy
+++ b/doc/repository.texy
@@ -37,7 +37,7 @@ final class BooksRepository extends Repository
 	 */
 	public function findByTags($name)
 	{
-		return $this->findBy(['this->tags->name' => $name]);
+		return $this->findBy(['tags->name' => $name]);
 	}
 }
 \--

--- a/src/Mapper/Memory/RelationshipMapperOneHasMany.php
+++ b/src/Mapper/Memory/RelationshipMapperOneHasMany.php
@@ -44,7 +44,7 @@ class RelationshipMapperOneHasMany implements IRelationshipMapper
 	{
 		assert($this->metadata->relationship !== null);
 		$className = $this->metadata->relationship->entityMetadata->className;
-		$data = $collection->findBy(["$className->{$this->joinStorageKey}->id" => $parent->getValue('id')])->fetchAll();
+		$data = $collection->findBy(["$className::{$this->joinStorageKey}->id" => $parent->getValue('id')])->fetchAll();
 		return new EntityIterator($data);
 	}
 

--- a/tests/cases/integration/Collection/collection.embeddables.phpt
+++ b/tests/cases/integration/Collection/collection.embeddables.phpt
@@ -20,7 +20,7 @@ class CollectionEmbeddablesTest extends DataTestCase
 {
 	public function testBasics()
 	{
-		$books1 = $this->orm->books->findBy(['this->price->cents>=' => 100]);
+		$books1 = $this->orm->books->findBy(['price->cents>=' => 100]);
 		Assert::same(0, $books1->count());
 		Assert::same(0, $books1->countStored());
 
@@ -28,7 +28,7 @@ class CollectionEmbeddablesTest extends DataTestCase
 		$book->price = new Money(100, Currency::CZK());
 		$this->orm->persistAndFlush($book);
 
-		$books2 = $this->orm->books->findBy(['this->price->cents>=' => 100]);
+		$books2 = $this->orm->books->findBy(['price->cents>=' => 100]);
 		Assert::same(1, $books2->count());
 		Assert::same(1, $books2->countStored());
 	}

--- a/tests/cases/integration/Collection/collection.phpt
+++ b/tests/cases/integration/Collection/collection.phpt
@@ -66,10 +66,10 @@ class CollectionTest extends DataTestCase
 
 	public function testCountOnLimitedWithJoin()
 	{
-		$collection = $this->orm->books->findBy(['this->author->name' => 'Writer 1'])->orderBy('id')->limitBy(5);
+		$collection = $this->orm->books->findBy(['author->name' => 'Writer 1'])->orderBy('id')->limitBy(5);
 		Assert::same(2, $collection->countStored());
 
-		$collection = $this->orm->tagFollowers->findBy(['this->tag->name' => 'Tag 1'])->orderBy('tag')->limitBy(3);
+		$collection = $this->orm->tagFollowers->findBy(['tag->name' => 'Tag 1'])->orderBy('tag')->limitBy(3);
 		Assert::same(1, $collection->countStored());
 	}
 
@@ -91,13 +91,13 @@ class CollectionTest extends DataTestCase
 	public function testOrdering()
 	{
 		$ids = $this->orm->books->findAll()
-			->orderBy('this->author->id', ICollection::DESC)
+			->orderBy('author->id', ICollection::DESC)
 			->orderBy('title', ICollection::ASC)
 			->fetchPairs(null, 'id');
 		Assert::same([3, 4, 1, 2], $ids);
 
 		$ids = $this->orm->books->findAll()
-			->orderBy('this->author->id', ICollection::DESC)
+			->orderBy('author->id', ICollection::DESC)
 			->orderBy('title', ICollection::DESC)
 			->fetchPairs(null, 'id');
 		Assert::same([4, 3, 2, 1], $ids);
@@ -108,7 +108,7 @@ class CollectionTest extends DataTestCase
 	{
 		$ids = $this->orm->books->findAll()
 			->orderByMultiple([
-				'this->author->id' => ICollection::DESC,
+				'author->id' => ICollection::DESC,
 				'title' => ICollection::ASC,
 			])
 			->fetchPairs(null, 'id');
@@ -116,7 +116,7 @@ class CollectionTest extends DataTestCase
 
 		$ids = $this->orm->books->findAll()
 			->orderByMultiple([
-				'this->author->id' => ICollection::DESC,
+				'author->id' => ICollection::DESC,
 				'title' => ICollection::DESC,
 			])
 			->fetchPairs(null, 'id');
@@ -127,25 +127,25 @@ class CollectionTest extends DataTestCase
 	public function testOrderingWithOptionalProperty()
 	{
 		$bookIds = $this->orm->books->findAll()
-			->orderBy('this->translator->name', ICollection::ASC_NULLS_FIRST)
+			->orderBy('translator->name', ICollection::ASC_NULLS_FIRST)
 			->orderBy('id')
 			->fetchPairs(null, 'id');
 		Assert::same([2, 1, 3, 4], $bookIds);
 
 		$bookIds = $this->orm->books->findAll()
-			->orderBy('this->translator->name', ICollection::DESC_NULLS_FIRST)
+			->orderBy('translator->name', ICollection::DESC_NULLS_FIRST)
 			->orderBy('id')
 			->fetchPairs(null, 'id');
 		Assert::same([2, 3, 4, 1], $bookIds);
 
 		$bookIds = $this->orm->books->findAll()
-			->orderBy('this->translator->name', ICollection::ASC_NULLS_LAST)
+			->orderBy('translator->name', ICollection::ASC_NULLS_LAST)
 			->orderBy('id')
 			->fetchPairs(null, 'id');
 		Assert::same([1, 3, 4, 2], $bookIds);
 
 		$bookIds = $this->orm->books->findAll()
-			->orderBy('this->translator->name', ICollection::DESC_NULLS_LAST)
+			->orderBy('translator->name', ICollection::DESC_NULLS_LAST)
 			->orderBy('id')
 			->fetchPairs(null, 'id');
 		Assert::same([3, 4, 1, 2], $bookIds);
@@ -179,8 +179,8 @@ class CollectionTest extends DataTestCase
 	public function testConditionsInSameJoin()
 	{
 		$books = $this->orm->books->findBy([
-			'this->author->name' => 'Writer 1',
-			'this->author->web'  => 'http://example.com/1',
+			'author->name' => 'Writer 1',
+			'author->web'  => 'http://example.com/1',
 		]);
 
 		Assert::same(2, $books->count());
@@ -199,8 +199,8 @@ class CollectionTest extends DataTestCase
 		$this->orm->books->persistAndFlush($book);
 
 		$books = $this->orm->books->findBy([
-			'this->author->name' => 'Writer 1',
-			'this->translator->web'  => 'http://example.com/2',
+			'author->name' => 'Writer 1',
+			'translator->web'  => 'http://example.com/2',
 		]);
 
 		Assert::same(1, $books->count());
@@ -229,8 +229,8 @@ class CollectionTest extends DataTestCase
 		$book4 = $this->orm->books->getById(4);
 
 		$books = $this->orm->books->findBy([
-			'this->nextPart->ean->code' => '123',
-			'this->previousPart->ean->code' => '456',
+			'nextPart->ean->code' => '123',
+			'previousPart->ean->code' => '456',
 		]);
 
 		Assert::count(1, $books);
@@ -308,7 +308,7 @@ class CollectionTest extends DataTestCase
 
 	public function testDistinct()
 	{
-		$books = $this->orm->tagFollowers->findBy(['this->tag->books->id' => 1]);
+		$books = $this->orm->tagFollowers->findBy(['tag->books->id' => 1]);
 		Assert::count(2, $books);
 	}
 }

--- a/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.phpt
@@ -222,7 +222,7 @@ class RelationshipManyHasManyTest extends DataTestCase
 
 	public function testCountStoredOnManyToManyCondition()
 	{
-		$books = $this->orm->books->findBy(['this->tags->name' => 'Tag 2']);
+		$books = $this->orm->books->findBy(['tags->name' => 'Tag 2']);
 		Assert::same(2, $books->countStored());
 	}
 }

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.phpt
@@ -137,7 +137,7 @@ class RelationshipOneHasManyTest extends DataTestCase
 	public function testOrderingWithJoins()
 	{
 		$book = $this->orm->books->getById(1);
-		$books = $book->translator->books->get()->orderBy('this->ean->code')->fetchAll();
+		$books = $book->translator->books->get()->orderBy('ean->code')->fetchAll();
 		Assert::count(2, $books);
 	}
 

--- a/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
@@ -32,8 +32,8 @@ class RelationshipOneHasOneTest extends DataTestCase
 		$this->orm->books->persistAndFlush($book);
 
 		$eans = $this->orm->eans
-			->findBy(['this->book->title' => 'GoT'])
-			->orderBy('this->book->title');
+			->findBy(['book->title' => 'GoT'])
+			->orderBy('book->title');
 		Assert::equal(1, $eans->countStored());
 		Assert::equal(1, $eans->count());
 		Assert::equal('GoTEAN', $eans->fetch()->code);
@@ -151,11 +151,11 @@ class RelationshipOneHasOneTest extends DataTestCase
 
 		$this->orm->books->persistAndFlush($book);
 
-		$books = $this->orm->books->findBy(['this->ean->code' => '1234']);
+		$books = $this->orm->books->findBy(['ean->code' => '1234']);
 		Assert::same(1, $books->countStored());
 		Assert::same(1, $books->count());
 
-		$eans = $this->orm->eans->findBy(['this->book->title' => 'Games of Thrones I']);
+		$eans = $this->orm->eans->findBy(['book->title' => 'Games of Thrones I']);
 		Assert::same(1, $eans->countStored());
 		Assert::same(1, $eans->count());
 	}

--- a/tests/cases/integration/Repository/repository.sti.phpt
+++ b/tests/cases/integration/Repository/repository.sti.phpt
@@ -7,21 +7,21 @@
 
 namespace NextrasTests\Orm\Integration\Repository;
 
-use Mockery;
+use Nextras\Dbal\Utils\DateTimeImmutable;
 use NextrasTests\Orm\Comment;
 use NextrasTests\Orm\DataTestCase;
 use NextrasTests\Orm\Thread;
 use Tester\Assert;
+
 
 $dic = require_once __DIR__ . '/../../../bootstrap.php';
 
 
 class RepositorySTITest extends DataTestCase
 {
-
 	public function testSelect()
 	{
-		$thread = $this->orm->contents->findBy(['NextrasTests\Orm\Thread->id' => 1])->fetch();
+		$thread = $this->orm->contents->findBy(['id' => 1])->fetch();
 		Assert::type(Thread::class, $thread);
 	}
 
@@ -37,6 +37,17 @@ class RepositorySTITest extends DataTestCase
 		Assert::type(Comment::class, $comment);
 	}
 
+
+	public function testFindByFiltering()
+	{
+		$result = $this->orm->contents->findBy([
+			'type' => 'comment',
+			'NextrasTests\Orm\Comment::repliedAt>' => new DateTimeImmutable('2020-01-01 18:00:00'),
+		]);
+		Assert::same(1, $result->count());
+		Assert::same(1, $result->countStored());
+		Assert::type(Comment::class, $result->fetch());
+	}
 }
 
 

--- a/tests/cases/unit/Collection/ArrayCollectionTest.phpt
+++ b/tests/cases/unit/Collection/ArrayCollectionTest.phpt
@@ -38,15 +38,15 @@ class ArrayCollectionTest extends TestCase
 
 		Assert::same($authors, iterator_to_array($collection));
 
-		Assert::same([$authors[1]], iterator_to_array($collection->findBy(['this->name' => 'Sansa'])));
-		Assert::same([$authors[1]], iterator_to_array($collection->findBy(['this->books->title' => 'Valyria 2'])));
-		Assert::same([$authors[0]], iterator_to_array($collection->findBy(['this->books->title' => 'Valyria 1'])));
-		Assert::same([$authors[0]], iterator_to_array($collection->findBy(['this->books->title' => 'The Wall'])));
+		Assert::same([$authors[1]], iterator_to_array($collection->findBy(['name' => 'Sansa'])));
+		Assert::same([$authors[1]], iterator_to_array($collection->findBy(['books->title' => 'Valyria 2'])));
+		Assert::same([$authors[0]], iterator_to_array($collection->findBy(['books->title' => 'Valyria 1'])));
+		Assert::same([$authors[0]], iterator_to_array($collection->findBy(['books->title' => 'The Wall'])));
 
 		// IN operator
 		Assert::same(
 			[$authors[0], $authors[1]],
-			iterator_to_array($collection->findBy(['this->books->title' => ['The Wall', 'Valyria 2']]))
+			iterator_to_array($collection->findBy(['books->title' => ['The Wall', 'Valyria 2']]))
 		);
 	}
 
@@ -70,7 +70,7 @@ class ArrayCollectionTest extends TestCase
 			$this->e(Book::class),
 		], $this->orm->books);
 
-		$collection = $collection->findBy(['this->author' => 1111]);
+		$collection = $collection->findBy(['author' => 1111]);
 		Assert::same(2, $collection->count());
 	}
 
@@ -82,31 +82,31 @@ class ArrayCollectionTest extends TestCase
 
 		Assert::same(
 			[$authors[2], $authors[0], $authors[1]],
-			iterator_to_array($collection->orderBy('this->name'))
+			iterator_to_array($collection->orderBy('name'))
 		);
 		Assert::same(
 			[$authors[1], $authors[0], $authors[2]],
-			iterator_to_array($collection->orderBy('this->name', ICollection::DESC))
+			iterator_to_array($collection->orderBy('name', ICollection::DESC))
 		);
 		Assert::same(
 			[$authors[0], $authors[2], $authors[1]],
-			iterator_to_array($collection->orderBy('this->born', ICollection::DESC))
+			iterator_to_array($collection->orderBy('born', ICollection::DESC))
 		);
 		Assert::same(
 			[$authors[2], $authors[1], $authors[0]],
-			iterator_to_array($collection->orderBy('this->age', ICollection::DESC)->orderBy('this->name'))
+			iterator_to_array($collection->orderBy('age', ICollection::DESC)->orderBy('name'))
 		);
 		Assert::same(
 			[$authors[2], $authors[1], $authors[0]],
-			iterator_to_array($collection->orderByMultiple(['this->age' => ICollection::DESC, 'this->name' => ICollection::ASC]))
+			iterator_to_array($collection->orderByMultiple(['age' => ICollection::DESC, 'name' => ICollection::ASC]))
 		);
 		Assert::same(
 			[$authors[1], $authors[2], $authors[0]],
-			iterator_to_array($collection->orderBy('this->age', ICollection::DESC)->orderBy('this->name', ICollection::DESC))
+			iterator_to_array($collection->orderBy('age', ICollection::DESC)->orderBy('name', ICollection::DESC))
 		);
 		Assert::same(
 			[$authors[1], $authors[2], $authors[0]],
-			iterator_to_array($collection->orderByMultiple(['this->age' => ICollection::DESC, 'this->name' => ICollection::DESC]))
+			iterator_to_array($collection->orderByMultiple(['age' => ICollection::DESC, 'name' => ICollection::DESC]))
 		);
 	}
 
@@ -153,7 +153,7 @@ class ArrayCollectionTest extends TestCase
 		Assert::same(
 			[$authors[0]],
 			iterator_to_array($collection
-				->findBy(['this->books->title' => ['Valyria 1', 'Valyria 2']])
+				->findBy(['books->title' => ['Valyria 1', 'Valyria 2']])
 				->orderBy('age')
 				->limitBy(1))
 		);
@@ -161,7 +161,7 @@ class ArrayCollectionTest extends TestCase
 		Assert::same(
 			[$authors[1]],
 			iterator_to_array($collection
-				->findBy(['this->books->title' => ['Valyria 1', 'Valyria 2']])
+				->findBy(['books->title' => ['Valyria 1', 'Valyria 2']])
 				->orderBy('age')
 				->limitBy(2, 1))
 		);
@@ -176,7 +176,7 @@ class ArrayCollectionTest extends TestCase
 		Assert::same(
 			1,
 			count($collection
-				->findBy(['this->books->title' => ['Valyria 1', 'Valyria 2']])
+				->findBy(['books->title' => ['Valyria 1', 'Valyria 2']])
 				->orderBy('age')
 				->limitBy(2, 1))
 		);

--- a/tests/cases/unit/Collection/ConditionParserHelperTest.phpt
+++ b/tests/cases/unit/Collection/ConditionParserHelperTest.phpt
@@ -27,18 +27,33 @@ class ConditionParserHelperTest extends TestCase
 		Assert::same(['column', '>'], ConditionParserHelper::parsePropertyOperator('column>'));
 		Assert::same(['column', '<'], ConditionParserHelper::parsePropertyOperator('column<'));
 
+		Assert::same(['column->name', '='], ConditionParserHelper::parsePropertyOperator('column->name'));
+		Assert::same(['column->name', '!='], ConditionParserHelper::parsePropertyOperator('column->name!='));
 		Assert::same(['this->column->name', '='], ConditionParserHelper::parsePropertyOperator('this->column->name'));
 		Assert::same(['this->column->name', '!='], ConditionParserHelper::parsePropertyOperator('this->column->name!='));
 
-		Assert::same(['NextrasTests\Orm\Book->column', '='], ConditionParserHelper::parsePropertyOperator('NextrasTests\Orm\Book->column'));
+		Assert::same(['NextrasTests\Orm\Book::column', '='], ConditionParserHelper::parsePropertyOperator('NextrasTests\Orm\Book::column'));
 	}
 
 
 	public function testParseExpression()
 	{
 		Assert::same([['column'], null], ConditionParserHelper::parsePropertyExpr('column'));
-		Assert::same([['column', 'name'], null], ConditionParserHelper::parsePropertyExpr('this->column->name'));
-		Assert::same([['column'], Book::class], ConditionParserHelper::parsePropertyExpr('NextrasTests\Orm\Book->column'));
+		Assert::same([['column', 'name'], null], ConditionParserHelper::parsePropertyExpr('column->name'));
+		Assert::same([['Book', 'column'], null], ConditionParserHelper::parsePropertyExpr('Book->column'));
+		Assert::same([['column'], Book::class], ConditionParserHelper::parsePropertyExpr('NextrasTests\Orm\Book::column'));
+
+		Assert::error(function () {
+			Assert::same([['column'], Book::class], ConditionParserHelper::parsePropertyExpr('NextrasTests\Orm\Book->column'));
+		}, E_USER_DEPRECATED, "Using STI class prefix 'NextrasTests\Orm\Book->' is deprecated; use with double-colon 'NextrasTests\Orm\Book::'.");
+
+		Assert::error(function() {
+			Assert::same([['column', 'name', 'test'], null], ConditionParserHelper::parsePropertyExpr('this->column->name->test'));
+		}, E_USER_DEPRECATED, "Using 'this->' is deprecated; use property traversing directly without 'this->'.");
+
+		Assert::error(function () {
+			Assert::same([['column', 'name'], null], ConditionParserHelper::parsePropertyExpr('this->column->name'));
+		}, E_USER_DEPRECATED, "Using 'this->' is deprecated; use property traversing directly without 'this->'.");
 	}
 
 
@@ -53,7 +68,7 @@ class ConditionParserHelperTest extends TestCase
 		}, InvalidArgumentException::class);
 
 		Assert::throws(function () {
-			ConditionParserHelper::parsePropertyExpr('Book->column->name');
+			ConditionParserHelper::parsePropertyExpr('Book::column->name');
 		}, InvalidArgumentException::class);
 	}
 }

--- a/tests/cases/unit/Collection/FetchPairsHelperTest.phpt
+++ b/tests/cases/unit/Collection/FetchPairsHelperTest.phpt
@@ -130,7 +130,7 @@ class FetchPairsHelperTest extends TestCase
 				'123' => 'Wall',
 				'456' => 'Landing',
 			],
-			FetchPairsHelper::process($data, 'code', 'this->book->title')
+			FetchPairsHelper::process($data, 'code', 'book->title')
 		);
 
 		Assert::same(
@@ -138,7 +138,7 @@ class FetchPairsHelperTest extends TestCase
 				'123' => $book1,
 				'456' => $book2,
 			],
-			FetchPairsHelper::process($data, 'code', 'this->book')
+			FetchPairsHelper::process($data, 'code', 'book')
 		);
 
 		Assert::same(
@@ -146,7 +146,7 @@ class FetchPairsHelperTest extends TestCase
 				'Wall' => 'jon snow',
 				'Landing' => 'Little Finger',
 			],
-			FetchPairsHelper::process($data, 'this->book->title', 'this->book->author->name')
+			FetchPairsHelper::process($data, 'book->title', 'book->author->name')
 		);
 
 		Assert::same(
@@ -154,7 +154,7 @@ class FetchPairsHelperTest extends TestCase
 				'jon snow' => '123',
 				'Little Finger' => '456',
 			],
-			FetchPairsHelper::process($data, 'this->book->author->name', 'this->code')
+			FetchPairsHelper::process($data, 'book->author->name', 'code')
 		);
 
 		Assert::same(
@@ -162,7 +162,7 @@ class FetchPairsHelperTest extends TestCase
 				10 => $one,
 				12 => $two,
 			],
-			FetchPairsHelper::process($data, 'this->book->id')
+			FetchPairsHelper::process($data, 'book->id')
 		);
 	}
 
@@ -182,7 +182,7 @@ class FetchPairsHelperTest extends TestCase
 					]
 				),
 			]);
-			FetchPairsHelper::process($data, null, 'this->books->id');
+			FetchPairsHelper::process($data, null, 'books->id');
 		}, InvalidStateException::class, "Part 'books' of the chain expression does not select IEntity value.");
 	}
 

--- a/tests/cases/unit/Entity/Reflection/MetadataParser.parseManyHasMany().phpt
+++ b/tests/cases/unit/Entity/Reflection/MetadataParser.parseManyHasMany().phpt
@@ -22,7 +22,7 @@ $dic = require_once __DIR__ . '/../../../../bootstrap.php';
  * @property int $id {primary}
  * @property mixed $test1 {m:m Foo::$property}
  * @property mixed $test2 {m:m Foo::$property, isMain=true}
- * @property mixed $test3 {m:m Foo::$property, orderBy=this->entity->id}
+ * @property mixed $test3 {m:m Foo::$property, orderBy=entity->id}
  * @property mixed $test4 {m:m Foo::$property, isMain=true, orderBy=[id, DESC]}
  * @property mixed $test5 {m:m Foo::$property, orderBy=id}
  * @property mixed $test6 {m:m Foo::$property, isMain=true, orderBy=id}
@@ -70,7 +70,7 @@ class MetadataParserParseManyHasManyTest extends TestCase
 		Assert::same(FooRepository::class, $propertyMeta->relationship->repository);
 		Assert::same(false, $propertyMeta->relationship->isMain);
 		Assert::same('property', $propertyMeta->relationship->property);
-		Assert::same(['this->entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
+		Assert::same(['entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
 
 		$propertyMeta = $metadata->getProperty('test4');
 		Assert::same(FooRepository::class, $propertyMeta->relationship->repository);

--- a/tests/cases/unit/Entity/Reflection/MetadataParser.parseOneHasMany().phpt
+++ b/tests/cases/unit/Entity/Reflection/MetadataParser.parseOneHasMany().phpt
@@ -21,9 +21,9 @@ $dic = require_once __DIR__ . '/../../../../bootstrap.php';
 /**
  * @property int $id {primary}
  * @property mixed $test1 {1:m Bar::$property}
- * @property mixed $test2 {1:m Bar::$property, orderBy=this->entity->id}
+ * @property mixed $test2 {1:m Bar::$property, orderBy=entity->id}
  * @property mixed $test3 {1:m Bar::$property, orderBy=[id,DESC]}
- * @property mixed $test4 {1:m Bar::$property, orderBy=[id=DESC, this->entity->id=ASC]}
+ * @property mixed $test4 {1:m Bar::$property, orderBy=[id=DESC, entity->id=ASC]}
  */
 class OneHasManyTestEntity extends Entity
 {}
@@ -59,7 +59,7 @@ class MetadataParserParseOneHasManyTest extends TestCase
 		$propertyMeta = $metadata->getProperty('test2');
 		Assert::same(BarRepository::class, $propertyMeta->relationship->repository);
 		Assert::same('property', $propertyMeta->relationship->property);
-		Assert::same(['this->entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
+		Assert::same(['entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
 		Assert::same(PropertyRelationshipMetadata::ONE_HAS_MANY, $propertyMeta->relationship->type);
 
 		$propertyMeta = $metadata->getProperty('test3');
@@ -71,7 +71,7 @@ class MetadataParserParseOneHasManyTest extends TestCase
 		$propertyMeta = $metadata->getProperty('test4');
 		Assert::same(BarRepository::class, $propertyMeta->relationship->repository);
 		Assert::same('property', $propertyMeta->relationship->property);
-		Assert::same(['id' => ICollection::DESC, 'this->entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
+		Assert::same(['id' => ICollection::DESC, 'entity->id' => ICollection::ASC], $propertyMeta->relationship->order);
 		Assert::same(PropertyRelationshipMetadata::ONE_HAS_MANY, $propertyMeta->relationship->type);
 	}
 }

--- a/tests/cases/unit/Mapper/Dbal/QueryBuilderHelperTest.phpt
+++ b/tests/cases/unit/Mapper/Dbal/QueryBuilderHelperTest.phpt
@@ -106,7 +106,7 @@ class QueryBuilderHelperTest extends TestCase
 		$this->conventions->shouldReceive('convertEntityToStorageKey')->once()->with('name')->andReturn('name');
 
 		$this->queryBuilder->shouldReceive('leftJoin')->once()->with('books', '[authors]', 'translator', '[books.translator_id] = [translator.id]');
-		$columnExpr = $this->builderHelper->processPropertyExpr($this->queryBuilder, 'this->translator->name')->column;
+		$columnExpr = $this->builderHelper->processPropertyExpr($this->queryBuilder, 'translator->name')->column;
 		Assert::same('translator.name', $columnExpr);
 	}
 
@@ -167,7 +167,7 @@ class QueryBuilderHelperTest extends TestCase
 		$this->queryBuilder->shouldReceive('getFromAlias')->twice()->andReturn('authors');
 		$this->queryBuilder->shouldReceive('groupBy')->twice()->with('%column[]', ['authors.id']);
 
-		$columnReference = $this->builderHelper->processPropertyExpr($this->queryBuilder, 'this->translatedBooks->tags->name');
+		$columnReference = $this->builderHelper->processPropertyExpr($this->queryBuilder, 'translatedBooks->tags->name');
 		Assert::same('translatedBooks_tags.name', $columnReference->column);
 	}
 
@@ -181,7 +181,7 @@ class QueryBuilderHelperTest extends TestCase
 			$this->mapper->shouldReceive('getConventions')->once()->andReturn($this->conventions);
 
 			$this->entityMetadata->shouldReceive('getProperty')->with('unknown')->andThrow(InvalidArgumentException::class);
-			$this->builderHelper->processPropertyExpr($this->queryBuilder, 'this->unknown->test');
+			$this->builderHelper->processPropertyExpr($this->queryBuilder, 'unknown->test');
 		}, InvalidArgumentException::class);
 	}
 
@@ -198,7 +198,7 @@ class QueryBuilderHelperTest extends TestCase
 			$this->entityMetadata->shouldReceive('getClassName')->once()->andReturn('Entity');
 			$this->entityMetadata->shouldReceive('getProperty')->with('name')->andReturn($propertyMetadata);
 
-			$this->builderHelper->processPropertyExpr($this->queryBuilder, 'this->name->test');
+			$this->builderHelper->processPropertyExpr($this->queryBuilder, 'name->test');
 		}, InvalidArgumentException::class);
 	}
 }

--- a/tests/db/array-data.php
+++ b/tests/db/array-data.php
@@ -8,6 +8,9 @@
 
 namespace NextrasTests\Orm;
 
+use Nextras\Dbal\Utils\DateTimeImmutable;
+
+
 /** @var Model $orm */
 
 $author1 = new Author();
@@ -96,9 +99,15 @@ $orm->tagFollowers->persist($tagFollower3);
 $thread = new Thread();
 $orm->contents->persist($thread);
 
-$comment = new Comment();
-$comment->thread = $thread;
-$orm->contents->persist($comment);
+$comment1 = new Comment();
+$comment1->thread = $thread;
+$comment1->repliedAt = new DateTimeImmutable('2020-01-01 12:00:00');
+$orm->contents->persist($comment1);
+
+$comment2 = new Comment();
+$comment2->thread = $thread;
+$comment2->repliedAt = new DateTimeImmutable('2020-01-02 12:00:00');
+$orm->contents->persist($comment2);
 
 $orm->flush();
 $orm->clear();

--- a/tests/db/mssql-data.sql
+++ b/tests/db/mssql-data.sql
@@ -50,5 +50,6 @@ INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (1, 1, '2014-01
 INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (3, 1, '2014-01-02 00:10:00');
 INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (2, 2, '2014-01-03 00:10:00');
 
-INSERT INTO contents (id, type, thread_id) VALUES (1, 'thread', NULL);
-INSERT INTO contents (id, type, thread_id) VALUES (2, 'comment', 1);
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (1, 'thread', NULL, NULL);
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (2, 'comment', 1, '2020-01-01 12:00:00');
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (3, 'comment', 1, '2020-01-02 12:00:00');

--- a/tests/db/mssql-init.sql
+++ b/tests/db/mssql-init.sql
@@ -76,6 +76,7 @@ CREATE TABLE contents (
 	id int NOT NULL,
 	type varchar(10) NOT NULL,
 	thread_id int,
+	replied_at datetimeoffset,
 	PRIMARY KEY (id),
 	CONSTRAINT contents_thread_id FOREIGN KEY (thread_id) REFERENCES contents (id) ON DELETE NO ACTION ON UPDATE NO ACTIOn
 );

--- a/tests/db/mysql-data.sql
+++ b/tests/db/mysql-data.sql
@@ -36,5 +36,6 @@ INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (1, 1, '2014-01
 INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (3, 1, '2014-01-02 00:10:00');
 INSERT INTO tag_followers (tag_id, author_id, created_at) VALUES (2, 2, '2014-01-03 00:10:00');
 
-INSERT INTO contents (id, type, thread_id) VALUES (1, 'thread', NULL);
-INSERT INTO contents (id, type, thread_id) VALUES (2, 'comment', 1);
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (1, 'thread', NULL, NULL);
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (2, 'comment', 1, '2020-01-01 12:00:00');
+INSERT INTO contents (id, type, thread_id, replied_at) VALUES (3, 'comment', 1, '2020-01-02 12:00:00');

--- a/tests/db/mysql-init.sql
+++ b/tests/db/mysql-init.sql
@@ -76,6 +76,7 @@ CREATE TABLE contents (
 	id int NOT NULL AUTO_INCREMENT,
 	type varchar(10) NOT NULL,
 	thread_id int,
+	replied_at timestamp,
 	PRIMARY KEY (id),
 	CONSTRAINT contents_parent_id FOREIGN KEY (thread_id) REFERENCES contents (id) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/tests/db/pgsql-data.sql
+++ b/tests/db/pgsql-data.sql
@@ -47,5 +47,6 @@ INSERT INTO "tag_followers" ("tag_id", "author_id", "created_at") VALUES (1, 1, 
 INSERT INTO "tag_followers" ("tag_id", "author_id", "created_at") VALUES (3, 1, '2014-01-02 00:10:00');
 INSERT INTO "tag_followers" ("tag_id", "author_id", "created_at") VALUES (2, 2, '2014-01-03 00:10:00');
 
-INSERT INTO "contents" ("id", "type", "thread_id") VALUES (1, 'thread', NULL);
-INSERT INTO "contents" ("id", "type", "thread_id") VALUES (2, 'comment', 1);
+INSERT INTO "contents" ("id", "type", "thread_id", "replied_at") VALUES (1, 'thread', NULL, NULL);
+INSERT INTO "contents" ("id", "type", "thread_id", "replied_at") VALUES (2, 'comment', 1, '2020-01-01 12:00:00');
+INSERT INTO "contents" ("id", "type", "thread_id", "replied_at") VALUES (3, 'comment', 1, '2020-01-02 12:00:00');

--- a/tests/db/pgsql-init.sql
+++ b/tests/db/pgsql-init.sql
@@ -76,6 +76,7 @@ CREATE TABLE "contents" (
 	"id" SERIAL4 NOT NULL,
 	"type" varchar(10) NOT NULL,
 	"thread_id" int,
+	"replied_at" timestamptz,
 	PRIMARY KEY ("id"),
 	CONSTRAINT "contents_thread_id" FOREIGN KEY ("thread_id") REFERENCES "contents" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/tests/inc/model/author/AuthorsRepository.php
+++ b/tests/inc/model/author/AuthorsRepository.php
@@ -18,6 +18,6 @@ final class AuthorsRepository extends Repository
 
 	public function findByTags($name)
 	{
-		return $this->findBy(['this->books->tags->name' => $name]);
+		return $this->findBy(['books->tags->name' => $name]);
 	}
 }

--- a/tests/inc/model/book/BooksRepository.php
+++ b/tests/inc/model/book/BooksRepository.php
@@ -29,7 +29,7 @@ final class BooksRepository extends Repository
 
 	public function findByTags($name)
 	{
-		return $this->findBy(['this->tags->name' => $name]);
+		return $this->findBy(['tags->name' => $name]);
 	}
 
 

--- a/tests/inc/model/contents/Comment.php
+++ b/tests/inc/model/contents/Comment.php
@@ -11,7 +11,7 @@ namespace NextrasTests\Orm;
 
 /**
  * @property-read string             $type   {default comment}
- * @property      Thread|null        $thread {m:1 Thread::$comments}
+ * @property      Thread             $thread {m:1 Thread::$comments}
  * @property      \DateTimeImmutable $repliedAt
  */
 class Comment extends ThreadCommentCommon

--- a/tests/inc/model/contents/Comment.php
+++ b/tests/inc/model/contents/Comment.php
@@ -10,8 +10,9 @@
 namespace NextrasTests\Orm;
 
 /**
- * @property-read string      $type   {default comment}
- * @property      Thread|null $thread {m:1 Thread::$comments}
+ * @property-read string             $type   {default comment}
+ * @property      Thread|null        $thread {m:1 Thread::$comments}
+ * @property      \DateTimeImmutable $repliedAt
  */
 class Comment extends ThreadCommentCommon
 {


### PR DESCRIPTION
… prefix (BC break!) [closes #368]