### PR TITLE
conventions: always use nullable modifier to let db handle type mismatch

### DIFF
--- a/src/Mapper/Dbal/Conventions/Conventions.php
+++ b/src/Mapper/Dbal/Conventions/Conventions.php
@@ -472,7 +472,7 @@ class Conventions implements IConventions
 
 		foreach ($this->platform->getColumns($this->storageTable->getNameFqn()) as $column) {
 			if (isset($types[$column->type])) {
-				$modifiers[$column->name] = $column->isNullable ? '%?dts' : '%dts';
+				$modifiers[$column->name] = '%?dts';
 			}
 		}
 


### PR DESCRIPTION
[close #177]