### PR TITLE
Entity->hasValue() should not set null value for uninitialized property

### DIFF
--- a/src/Entity/ImmutableDataTrait.php
+++ b/src/Entity/ImmutableDataTrait.php
@@ -83,7 +83,7 @@ trait ImmutableDataTrait
 	private function internalHasValue(PropertyMetadata $metadata, string $name): bool
 	{
 		if (!isset($this->validated[$name])) {
-			$this->initProperty($metadata, $name);
+			$this->initProperty($metadata, $name, false);
 		}
 
 		if ($this->data[$name] instanceof IPropertyContainer) {

--- a/src/Relationships/HasOne.php
+++ b/src/Relationships/HasOne.php
@@ -11,7 +11,6 @@ use Nextras\Orm\Entity\Reflection\PropertyRelationshipMetadata;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use Nextras\Orm\Exception\InvalidStateException;
 use Nextras\Orm\Exception\NullValueException;
-use Nextras\Orm\Mapper\IRelationshipMapper;
 use Nextras\Orm\Repository\IRepository;
 use function assert;
 
@@ -36,10 +35,10 @@ abstract class HasOne implements IRelationshipContainer
 	 */
 	protected $collection;
 
-	/** @var bool */
+	/** @var bool Is value validated against storage? */
 	protected $isValueValidated = true;
 
-	/** @var bool */
+	/** @var bool Is raw value loaded from storage and not converted yet? */
 	protected $isValueFromStorage = false;
 
 	/** @var IEntity|string|int|null */
@@ -56,9 +55,6 @@ abstract class HasOne implements IRelationshipContainer
 
 	/** @var bool */
 	protected $isModified = false;
-
-	/** @var IRelationshipMapper */
-	protected $relationshipMapper;
 
 
 	public function __construct(PropertyMetadata $metadata)

--- a/src/Relationships/OneHasOne.php
+++ b/src/Relationships/OneHasOne.php
@@ -5,11 +5,19 @@ namespace Nextras\Orm\Relationships;
 
 use Nextras\Orm\Collection\ICollection;
 use Nextras\Orm\Entity\IEntity;
+use Nextras\Orm\Entity\Reflection\PropertyMetadata;
 use function assert;
 
 
 class OneHasOne extends HasOne
 {
+	public function __construct(PropertyMetadata $metadata)
+	{
+		parent::__construct($metadata);
+		$this->isValueFromStorage = !$this->metadataRelationship->isMain;
+	}
+
+
 	/** {@inheritDoc} */
 	protected function createCollection(): ICollection
 	{
@@ -29,7 +37,7 @@ class OneHasOne extends HasOne
 
 	public function getRawValue()
 	{
-		if (!$this->isValueValidated && !$this->metadataRelationship->isMain) {
+		if ($this->isValueFromStorage && !$this->metadataRelationship->isMain) {
 			$this->initValue();
 		}
 		return parent::getRawValue();
@@ -38,7 +46,7 @@ class OneHasOne extends HasOne
 
 	public function hasInjectedValue(): bool
 	{
-		if (!$this->isValueValidated && !$this->metadataRelationship->isMain) {
+		if ($this->isValueFromStorage && !$this->metadataRelationship->isMain) {
 			$this->initValue();
 		}
 		return parent::hasInjectedValue();

--- a/tests/cases/integration/Entity/entity.hasValue().phpt
+++ b/tests/cases/integration/Entity/entity.hasValue().phpt
@@ -7,8 +7,12 @@
 namespace NextrasTests\Orm\Integration\Entity;
 
 
+use Nextras\Orm\Entity\AbstractEntity;
+use Nextras\Orm\Entity\Reflection\EntityMetadata;
+use Nextras\Orm\Model\MetadataStorage;
 use NextrasTests\Orm\Author;
 use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Ean;
 use Tester\Assert;
 
 
@@ -28,6 +32,23 @@ class EntityHasValueTest extends DataTestCase
 		Assert::false($author->hasValue('name'));
 		Assert::true($author->hasValue('web'));
 		Assert::true($author->hasValue('age'));
+
+		// avoid default ean constructor not to set the default type
+		$ean = new class extends Ean {
+			/** @noinspection PhpMissingParentConstructorInspection */
+			// @phpstan-ignore-next-line
+			public function __construct()
+			{
+				AbstractEntity::__construct();
+			}
+
+
+			protected function createMetadata(): EntityMetadata
+			{
+				return MetadataStorage::get(Ean::class);
+			}
+		};
+		Assert::false($ean->hasValue('type'));
 	}
 
 }

--- a/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
@@ -233,6 +233,19 @@ class RelationshipOneHasOneTest extends DataTestCase
 		$bookId = $ean->getRawValue('book');
 		Assert::equal(1, $bookId);
 	}
+
+
+	public function testHasValue(): void
+	{
+		$ean = new Ean();
+		$ean->code = '1234';
+		$ean->book = $this->orm->books->getByIdChecked(1);
+		$this->orm->eans->persistAndFlush($ean);
+		$this->orm->clear();
+
+		$ean = $this->orm->eans->getByChecked(['code' => '1234']);
+		Assert::true($ean->hasValue('book'));
+	}
 }
 
 

--- a/tests/inc/TestCase.php
+++ b/tests/inc/TestCase.php
@@ -44,7 +44,7 @@ class TestCase extends Tester\TestCase
 		$configurator = new Configurator();
 
 		if (!Helper::isRunByRunner()) {
-			$configurator->enableDebugger(__DIR__ . '/log');
+			$configurator->enableDebugger(__DIR__ . '/../log');
 		}
 
 		$hashData = json_encode($dbConfig);

--- a/tests/inc/model/ean/Ean.php
+++ b/tests/inc/model/ean/Ean.php
@@ -12,7 +12,7 @@ use Nextras\Orm\Entity\Entity;
  * @property Book     $book {1:1 Book::$ean}
  * @property EanType  $type {wrapper TestEnumPropertyWrapper}
  */
-final class Ean extends Entity
+class Ean extends Entity
 {
 	public function __construct(EanType $type = null)
 	{


### PR DESCRIPTION
`Entity->hasValue()` should not set value for property which does not have value yet. In most cases it will just set null and gets eventually overriden, but in case of enum wrapper which expects fixed subset of values, null (which is out of that subset) raises an exception when enum is tried to be created.

To verify issue, drop the source change in ImmutableDataTrait - included test will fail.