### PR TITLE
Merging same JOINs together & introduction of independent JOINs

### DIFF
--- a/src/Collection/Aggregations/AnyAggregator.php
+++ b/src/Collection/Aggregations/AnyAggregator.php
@@ -16,10 +16,13 @@ use function array_pop;
  */
 class AnyAggregator implements IDbalAggregator, IArrayAggregator
 {
-	/** @var string */
+	/** @var literal-string */
 	private $aggregateKey;
 
 
+	/**
+	 * @param literal-string $aggregateKey
+	 */
 	public function __construct(string $aggregateKey = 'any')
 	{
 		$this->aggregateKey = $aggregateKey;

--- a/src/Collection/Aggregations/CountAggregator.php
+++ b/src/Collection/Aggregations/CountAggregator.php
@@ -20,10 +20,13 @@ class CountAggregator implements IDbalAggregator, IArrayAggregator
 	/** @var int */
 	private $atMost;
 
-	/** @var string */
+	/** @var literal-string */
 	private $aggregateKey;
 
 
+	/**
+	 * @param literal-string $aggregateKey
+	 */
 	public function __construct(
 		int $atLeast,
 		int $atMost,

--- a/src/Collection/Aggregations/IAggregator.php
+++ b/src/Collection/Aggregations/IAggregator.php
@@ -5,5 +5,8 @@ namespace Nextras\Orm\Collection\Aggregations;
 
 interface IAggregator
 {
+	/**
+	 * @return literal-string
+	 */
 	public function getAggregateKey(): string;
 }

--- a/src/Collection/Aggregations/NoneAggregator.php
+++ b/src/Collection/Aggregations/NoneAggregator.php
@@ -16,10 +16,13 @@ use function array_pop;
  */
 class NoneAggregator implements IDbalAggregator, IArrayAggregator
 {
-	/** @var string */
+	/** @var literal-string */
 	private $aggregateKey;
 
 
+	/**
+	 * @param literal-string $aggregateKey
+	 */
 	public function __construct(string $aggregateKey = 'none')
 	{
 		$this->aggregateKey = $aggregateKey;

--- a/src/Collection/Functions/BaseAggregateFunction.php
+++ b/src/Collection/Functions/BaseAggregateFunction.php
@@ -84,7 +84,7 @@ abstract class BaseAggregateFunction implements IArrayFunction, IQueryBuilderFun
 
 			public function getAggregateKey(): string
 			{
-				return '_' . strtolower($this->sqlFunction);
+				return '_' . $this->sqlFunction;
 			}
 
 

--- a/src/Collection/Helpers/DbalQueryBuilderHelper.php
+++ b/src/Collection/Helpers/DbalQueryBuilderHelper.php
@@ -8,6 +8,7 @@ use Nette\Utils\Json;
 use Nextras\Dbal\Platforms\Data\Column;
 use Nextras\Dbal\QueryBuilder\QueryBuilder;
 use Nextras\Orm\Collection\Aggregations\AnyAggregator;
+use Nextras\Orm\Collection\Aggregations\IAggregator;
 use Nextras\Orm\Collection\Aggregations\IDbalAggregator;
 use Nextras\Orm\Collection\Functions\ConjunctionOperatorFunction;
 use Nextras\Orm\Collection\Functions\IQueryBuilderFunction;
@@ -302,6 +303,7 @@ class DbalQueryBuilderHelper
 					$tokens,
 					$joins,
 					$property,
+					$aggregator,
 					$currentConventions,
 					$currentMapper,
 					$currentAlias,
@@ -366,6 +368,7 @@ class DbalQueryBuilderHelper
 		array $tokens,
 		array &$joins,
 		PropertyMetadata $property,
+		?IAggregator $aggregator,
 		IConventions $currentConventions,
 		DbalMapper $currentMapper,
 		string $currentAlias,
@@ -436,6 +439,10 @@ class DbalQueryBuilderHelper
 		$targetTable = $targetMapper->getTableName();
 		/** @phpstan-var literal-string $targetAlias */
 		$targetAlias = self::getAlias($tokens[$tokenIndex], array_slice($tokens, 0, $tokenIndex));
+		if ($makeDistinct) {
+			$aggregator = $aggregator ?? new AnyAggregator();
+			$targetAlias .= '_' . $aggregator->getAggregateKey();
+		}
 		$joins[] = new DbalJoinEntry(
 			"%table",
 			[$targetTable],


### PR DESCRIPTION
Merged as part of #545:
- [x] rework `DbalJoinEntry`
- [x] merge join conditions targeting the same table (alias)
- [x] remove the same on-expression duplicates
- [x] defer JOINs materialization to SQL in `DbalCollection`
- [x] rework repeated `findBy()` calls to reuse `ICollection::AND` infrastructure to utilize JOINs merging
----------------

Merged as part of #546:
- [x] unify groupBy handling via `DbalJoinEntry`
- [x] refactor aggregators to instance passing instead of custom collection function handling  (rework aggregators to single implementation)
- [x] refactor Array to properly implement aggregation on *Junction level
- [x] fix Array handling dependent aggregated conditions
- [x] move/add table alias handling for `IAggregator`
- [x] allow passing custom table aggregation logic
----------------

This PR:
- [x] wire IAggregation key to table aliasing logic in Dbal

Closes #541 
Closes #526