### PR TITLE
Add missing array key checks when using the `debug_backtrace()` function

### DIFF
--- a/src/Repository/PersistenceHelper.php
+++ b/src/Repository/PersistenceHelper.php
@@ -65,7 +65,7 @@ class PersistenceHelper
 				foreach ($bt as $item) {
 					if ($item['function'] === 'getCascadeQueue') {
 						break;
-					} elseif ($item['function'] === 'addRelationshipToQueue') {
+					} elseif ($item['function'] === 'addRelationshipToQueue' && isset($item['args'])) {
 						$cycle[] = get_class($item['args'][0]) . '::$' . $item['args'][1]->name;
 					}
 				}


### PR DESCRIPTION
The keys returned by the `debug_backtrace()` function for each stacktrace frame are almost all optional. This PR adds the missing checks to avoid the code to crash if the keys are not present