### PR TITLE
bug 1:1 relationship

### DIFF
--- a/src/Relationships/HasOne.php
+++ b/src/Relationships/HasOne.php
@@ -231,7 +231,7 @@ abstract class HasOne implements IRelationshipContainer
 	 */
 	protected function getValue(bool $allowPreloadContainer = true): ?IEntity
 	{
-		if (!$this->isValueValidated && $this->value !== null) {
+		if (!$this->isValueValidated && ($this->value !== null || $this->metadata->isNullable)) {
 			$this->initValue($allowPreloadContainer);
 		}
 

--- a/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
@@ -234,6 +234,22 @@ class RelationshipOneHasOneTest extends DataTestCase
 		Assert::equal(1, $bookId);
 	}
 
+	public function testGetEntity(): void
+	{
+		$ean = new Ean();
+		$ean->code = '1234';
+		$ean->book = $this->orm->books->getByIdChecked(1);
+		$this->orm->eans->persistAndFlush($ean);
+		$eanId = $ean->id;
+
+		$this->orm->clear();
+
+		$ean = $this->orm->eans->getByIdChecked($eanId);
+		$book = $ean->book;
+		Assert::equal(1, $book->id);
+
+	}
+
 
 	public function testHasValue(): void
 	{

--- a/tests/inc/model/ean/Ean.php
+++ b/tests/inc/model/ean/Ean.php
@@ -9,7 +9,7 @@ use Nextras\Orm\Entity\Entity;
 /**
  * @property int|null $id   {primary}
  * @property string   $code
- * @property Book     $book {1:1 Book::$ean}
+ * @property Book|null     $book {1:1 Book::$ean}
  * @property EanType  $type {wrapper TestEnumPropertyWrapper}
  */
 class Ean extends Entity


### PR DESCRIPTION
Nasel jsem chybku viz:

```php 
public function testGetEntity(): void
	{
		$ean = new Ean();
		$ean->code = '1234';
		$ean->book = $this->orm->books->getByIdChecked(1);
		$this->orm->eans->persistAndFlush($ean);
		$eanId = $ean->id;

		$this->orm->clear();

		$ean = $this->orm->eans->getByIdChecked($eanId);
		$book = $ean->book;
		Assert::equal(1, $book->id);

	}