### PR TITLE
mixed type allows null

### DIFF
--- a/src/Entity/Reflection/MetadataParser.php
+++ b/src/Entity/Reflection/MetadataParser.php
@@ -244,7 +244,7 @@ class MetadataParser implements IMetadataParser
 			$parsedTypes[$type] = true;
 		}
 
-		$property->isNullable = $isNullable || isset($parsedTypes['null']) || isset($parsedTypes['NULL']);
+		$property->isNullable = $isNullable || isset($parsedTypes['null']) || isset($parsedTypes['NULL']) || isset($parsedTypes['mixed']);
 		unset($parsedTypes['null'], $parsedTypes['NULL']);
 		$property->types = $parsedTypes;
 	}


### PR DESCRIPTION
Allows properties with mixed type to contain null.

Also dropped the uppercase NULL, because $parsedTypes always contains only lowercase null 
https://github.com/nextras/orm/blob/2abc593a3bb7a80bdb9ad94f3e9c47ead65ea69f/src/Entity/Reflection/MetadataParser.php#L232-L233