### PR TITLE
Use spl_object_id instead of spl_object_hash

### DIFF
--- a/src/Collection/HasManyCollection.php
+++ b/src/Collection/HasManyCollection.php
@@ -15,7 +15,7 @@ use function count;
 use function get_class;
 use function iterator_count;
 use function iterator_to_array;
-use function spl_object_hash;
+use function spl_object_id;
 
 
 /**
@@ -193,7 +193,7 @@ class HasManyCollection implements ICollection
 
 		$all = [];
 		foreach ($storageCollection as $entity) {
-			$all[spl_object_hash($entity)] = $entity;
+			$all[spl_object_id($entity)] = $entity;
 		}
 		foreach ($toAdd as $hash => $entity) {
 			$all[$hash] = $entity;

--- a/src/Mapper/Dbal/DbalMapper.php
+++ b/src/Mapper/Dbal/DbalMapper.php
@@ -284,7 +284,7 @@ abstract class DbalMapper implements IMapper
 		?IMapper $sourceMapper = null
 	): IRelationshipMapper
 	{
-		$key = $type . spl_object_hash($metadata) . $metadata->name;
+		$key = $type . spl_object_id($metadata) . $metadata->name;
 		if (!isset($this->cacheRM[$key])) {
 			$this->cacheRM[$key] = $this->createRelationshipMapper($type, $metadata, $sourceMapper);
 		}

--- a/src/Relationships/HasMany.php
+++ b/src/Relationships/HasMany.php
@@ -18,7 +18,7 @@ use function array_values;
 use function assert;
 use function is_array;
 use function iterator_count;
-use function spl_object_hash;
+use function spl_object_id;
 
 
 /**
@@ -50,19 +50,19 @@ abstract class HasMany implements IRelationshipCollection
 
 	/**
 	 * @var IEntity[]
-	 * @phpstan-var array<string, E>
+	 * @phpstan-var array<int, E>
 	 */
 	protected $toAdd = [];
 
 	/**
 	 * @var IEntity[]
-	 * @phpstan-var array<string,E>
+	 * @phpstan-var array<int,E>
 	 */
 	protected $toRemove = [];
 
 	/**
 	 * @var IEntity[]
-	 * @phpstan-var array<string, E>
+	 * @phpstan-var array<int, E>
 	 */
 	protected $tracked = [];
 
@@ -176,13 +176,13 @@ abstract class HasMany implements IRelationshipCollection
 			return null;
 		}
 
-		$entityHash = spl_object_hash($entity);
+		$entityId = spl_object_id($entity);
 
-		if (isset($this->toRemove[$entityHash])) {
-			unset($this->toRemove[$entityHash]);
-			$this->tracked[$entityHash] = $entity;
+		if (isset($this->toRemove[$entityId])) {
+			unset($this->toRemove[$entityId]);
+			$this->tracked[$entityId] = $entity;
 		} else {
-			$this->toAdd[$entityHash] = $entity;
+			$this->toAdd[$entityId] = $entity;
 		}
 
 		$this->updateRelationshipAdd($entity);
@@ -203,13 +203,13 @@ abstract class HasMany implements IRelationshipCollection
 			return null;
 		}
 
-		$entityHash = spl_object_hash($entity);
+		$entityId = spl_object_id($entity);
 
-		if (isset($this->toAdd[$entityHash])) {
-			unset($this->toAdd[$entityHash]);
+		if (isset($this->toAdd[$entityId])) {
+			unset($this->toAdd[$entityId]);
 		} else {
-			$this->toRemove[$entityHash] = $entity;
-			unset($this->tracked[$entityHash]);
+			$this->toRemove[$entityId] = $entity;
+			unset($this->tracked[$entityId]);
 		}
 
 		$this->updateRelationshipRemove($entity);
@@ -226,7 +226,7 @@ abstract class HasMany implements IRelationshipCollection
 			return false;
 		}
 
-		$entityHash = spl_object_hash($entity);
+		$entityHash = spl_object_id($entity);
 		if (isset($this->toAdd[$entityHash])) {
 			return true;
 
@@ -248,12 +248,12 @@ abstract class HasMany implements IRelationshipCollection
 		foreach ($data as $entry) {
 			$entity = $this->createEntity($entry);
 			if ($entity === null) continue;
-			$wanted[spl_object_hash($entity)] = $entity;
+			$wanted[spl_object_id($entity)] = $entity;
 		}
 
 		$current = [];
 		foreach ($this->getCollection() as $entity) {
-			$current[spl_object_hash($entity)] = $entity;
+			$current[spl_object_id($entity)] = $entity;
 		}
 
 		$toRemove = array_diff_key($current, $wanted);
@@ -327,7 +327,7 @@ abstract class HasMany implements IRelationshipCollection
 	 */
 	public function trackEntity(IEntity $entity): void
 	{
-		$this->tracked[spl_object_hash($entity)] = $entity;
+		$this->tracked[spl_object_id($entity)] = $entity;
 	}
 
 

--- a/src/Relationships/IRelationshipCollection.php
+++ b/src/Relationships/IRelationshipCollection.php
@@ -88,7 +88,7 @@ interface IRelationshipCollection extends IPropertyContainer, IEntityAwareProper
 	/**
 	 * Returns IEntity for persistence.
 	 * @return IEntity[]
-	 * @phpstan-return array<string, E>
+	 * @phpstan-return array<int, E>
 	 * @ignore
 	 * @internal
 	 */

--- a/src/Repository/RemovalHelper.php
+++ b/src/Repository/RemovalHelper.php
@@ -20,7 +20,7 @@ class RemovalHelper
 {
 	/**
 	 * @param array<string, IEntity|IRelationshipCollection<IEntity>> $queuePersist
-	 * @param array<string, IEntity|bool> $queueRemove
+	 * @param array<int, IEntity|bool> $queueRemove
 	 */
 	public static function getCascadeQueueAndSetNulls(
 		IEntity $entity,
@@ -30,7 +30,7 @@ class RemovalHelper
 		array &$queueRemove
 	): void
 	{
-		$entityHash = spl_object_hash($entity);
+		$entityHash = spl_object_id($entity);
 		if (isset($queueRemove[$entityHash])) {
 			return;
 		}
@@ -49,7 +49,7 @@ class RemovalHelper
 		}
 
 		foreach ($prePersist as $value) {
-			$queuePersist[spl_object_hash($value)] = $value;
+			$queuePersist[spl_object_id($value)] = $value;
 		}
 		$queueRemove[$entityHash] = true;
 		foreach ($pre as $value) {
@@ -59,7 +59,7 @@ class RemovalHelper
 				foreach ($value->getIterator() as $subValue) {
 					static::getCascadeQueueAndSetNulls($subValue, $model, true, $queuePersist, $queueRemove);
 				}
-				$queuePersist[spl_object_hash($value)] = $value;
+				$queuePersist[spl_object_id($value)] = $value;
 			}
 		}
 		unset($queueRemove[$entityHash]);
@@ -72,7 +72,7 @@ class RemovalHelper
 				foreach ($value->getIterator() as $subValue) {
 					static::getCascadeQueueAndSetNulls($subValue, $model, true, $queuePersist, $queueRemove);
 				}
-				$queuePersist[spl_object_hash($value)] = $value;
+				$queuePersist[spl_object_id($value)] = $value;
 			}
 		}
 	}
@@ -127,7 +127,7 @@ class RemovalHelper
 	/**
 	 * @param PropertyMetadata[] $metadata
 	 * @param array<string, IEntity|IRelationshipCollection<IEntity>> $pre
-	 * @param array<string, IEntity|bool> $queueRemove
+	 * @param array<int, IEntity|bool> $queueRemove
 	 */
 	private static function setNulls(
 		IEntity $entity,
@@ -168,7 +168,7 @@ class RemovalHelper
 				assert($property instanceof HasOne);
 				if ($reverseProperty !== null) {
 					$reverseEntity = $property->getEntity();
-					if ($reverseEntity === null || isset($queueRemove[spl_object_hash($reverseEntity)])) {
+					if ($reverseEntity === null || isset($queueRemove[spl_object_id($reverseEntity)])) {
 						// reverse side is also being removed, do not set null to this relationship
 						continue;
 					}


### PR DESCRIPTION
spl_object_id() should be bit more performant than spl_object_hash()

I found in PHP [internals communication](https://externals.io/message/79255) that there is one difference - spl_object_hash() should return same hash for equal objects. But it does not seem to be the case https://3v4l.org/pSNBF