### PR TITLE
Use PhpDocParser for property parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 		"ext-ctype": "*",
 		"nette/caching": "~3.2 || ~3.1.3",
 		"nette/utils": "~3.0 || ~4.0",
-		"nextras/dbal": "dev-main#bf717b4b02b45f44b7c25b3b1c6a14a19cc59847"
+		"nextras/dbal": "dev-main#bf717b4b02b45f44b7c25b3b1c6a14a19cc59847",
+		"phpstan/phpdoc-parser": "2.0.x-dev"
 	},
 	"require-dev": {
 		"nette/bootstrap": "~3.1",

--- a/tests/cases/unit/Entity/Reflection/PropertyMetadata.isValid().phpt
+++ b/tests/cases/unit/Entity/Reflection/PropertyMetadata.isValid().phpt
@@ -31,7 +31,6 @@ require_once __DIR__ . '/../../../../bootstrap.php';
  * @property array $array1
  * @property int[] $array2
  * @property object $object
- * @property scalar $scalar
  * @property mixed $mixed
  * @property ArrayHash $type
  * @property bool|NULL $nullable1
@@ -232,30 +231,6 @@ class PropertyMetadataIsValidTest extends TestCase
 		Assert::true($property->isValid($val));
 
 		$val = [];
-		Assert::false($property->isValid($val));
-	}
-
-
-	public function testScalar(): void
-	{
-		$property = $this->metadata->getProperty('scalar');
-
-		$val = 1;
-		Assert::true($property->isValid($val));
-
-		$val = 1.0;
-		Assert::true($property->isValid($val));
-
-		$val = false;
-		Assert::true($property->isValid($val));
-
-		$val = 'string';
-		Assert::true($property->isValid($val));
-
-		$val = [];
-		Assert::false($property->isValid($val));
-
-		$val = (object) [];
 		Assert::false($property->isValid($val));
 	}
 


### PR DESCRIPTION
This is the first part for #521: adoption of PHPStan's PhpDocParser.
For 5.0 I do not plan to introduce any more parsing features, but this should at least provide some validation consistency.

New behavior:
- **[new]** When the type is not simple enough -> exception
- **[new]** Understands (parser as a simple array) array shapes
- **[new]** Understands (parses as a simple object) object shapes
- Supports union & intersection types
- Parser all previously supported types
- Prases nullability in both forms (`?`, `|null`)
- Removes support for `scalar` type (BC break!)