### PR TITLE
php84 deprecation fixes

### DIFF
--- a/src/Collection/ICollection.php
+++ b/src/Collection/ICollection.php
@@ -154,7 +154,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Limits number of rows.
 	 * @return static
 	 */
-	public function limitBy(int $limit, int $offset = null): ICollection;
+	public function limitBy(int $limit, ?int $offset = null): ICollection;
 
 
 	/**

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -61,7 +61,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
-	public function isModified(string $name = null): bool
+	public function isModified(?string $name = null): bool
 	{
 		if ($name === null) {
 			return (bool) $this->modified;
@@ -72,7 +72,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
-	public function setAsModified(string $name = null): void
+	public function setAsModified(?string $name = null): void
 	{
 		$this->modified[$name] = true;
 	}

--- a/src/Entity/IEntity.php
+++ b/src/Entity/IEntity.php
@@ -90,13 +90,13 @@ interface IEntity
 	/**
 	 * Returns true if the entity is modified or the column $name is modified.
 	 */
-	public function isModified(string $name = null): bool;
+	public function isModified(?string $name = null): bool;
 
 
 	/**
 	 * Sets the entity or the column as modified.
 	 */
-	public function setAsModified(string $name = null): void;
+	public function setAsModified(?string $name = null): void;
 
 
 	/**

--- a/src/Repository/IRepository.php
+++ b/src/Repository/IRepository.php
@@ -63,7 +63,7 @@ interface IRepository
 	 * Returns entity metadata.
 	 * @param string|null $entityClass for STI (must extends base class)
 	 */
-	public function getEntityMetadata(string $entityClass = null): EntityMetadata;
+	public function getEntityMetadata(?string $entityClass = null): EntityMetadata;
 
 
 	/**

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -142,7 +142,7 @@ abstract class Repository implements IRepository
 	 * @param IMapper $mapper
 	 * @param IDependencyProvider $dependencyProvider
 	 */
-	public function __construct(IMapper $mapper, IDependencyProvider $dependencyProvider = null)
+	public function __construct(IMapper $mapper, ?IDependencyProvider $dependencyProvider = null)
 	{
 		$this->mapper = $mapper;
 		$this->mapper->setRepository($this);
@@ -368,7 +368,7 @@ abstract class Repository implements IRepository
 
 
 	/** {@inheritdoc} */
-	public function getEntityMetadata(string $entityClass = null): EntityMetadata
+	public function getEntityMetadata(?string $entityClass = null): EntityMetadata
 	{
 		$classNames = static::getEntityClassNames();
 		if ($entityClass !== null && !in_array($entityClass, $classNames, true)) {


### PR DESCRIPTION
This MR fixes deprecations with php 8.4

`Implicitly marking parameter $variable as nullable is deprecated, the explicit nullable type must be used instead`