### PR TITLE
Model PrimaryProxy modifier as property wrapper

### DIFF
--- a/src/Collection/Helpers/ArrayCollectionHelper.php
+++ b/src/Collection/Helpers/ArrayCollectionHelper.php
@@ -148,7 +148,8 @@ class ArrayCollectionHelper
 			} else {
 				$value = $property->convertToRawValue($value);
 			}
-		} elseif (
+		}
+		if (
 			(isset($propertyMetadata->types[DateTimeImmutable::class]) || isset($propertyMetadata->types[\Nextras\Dbal\Utils\DateTimeImmutable::class]))
 			&& $value !== null
 		) {

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -397,61 +397,6 @@ abstract class AbstractEntity implements IEntity
 
 	/**
 	 * @param mixed $value
-	 * @return mixed
-	 */
-	private function setterPrimaryProxy($value, PropertyMetadata $metadata) // @phpstan-ignore-line
-	{
-		$keys = $this->metadata->getPrimaryKey();
-		if (!$metadata->isVirtual) {
-			return $value;
-		}
-
-		if (count($keys) === 1) {
-			$value = [$value];
-		} elseif (!is_array($value)) {
-			$class = get_class($this);
-			throw new InvalidArgumentException("Value for $class::\$id has to be passed as array.");
-		}
-
-		if (count($keys) !== count($value)) {
-			$class = get_class($this);
-			throw new InvalidArgumentException("Value for $class::\$id has insufficient number of parameters.");
-		}
-
-		foreach ($keys as $key) {
-			$this->setRawValue($key, array_shift($value));
-		}
-		return null;
-	}
-
-
-	/**
-	 * @param mixed $value
-	 * @return mixed
-	 */
-	private function getterPrimaryProxy($value, PropertyMetadata $metadata) // @phpstan-ignore-line
-	{
-		if ($this->persistedId !== null) {
-			return $this->persistedId;
-		} elseif (!$metadata->isVirtual) {
-			return $value;
-		}
-
-		$id = [];
-		$keys = $this->getMetadata()->getPrimaryKey();
-		foreach ($keys as $key) {
-			$id[] = $this->getRawValue($key);
-		}
-		if (count($keys) === 1) {
-			return $id[0];
-		} else {
-			return $id;
-		}
-	}
-
-
-	/**
-	 * @param mixed $value
 	 */
 	private function internalSetValue(PropertyMetadata $metadata, string $name, $value): void
 	{

--- a/src/Entity/PropertyWrapper/PrimaryProxyWrapper.php
+++ b/src/Entity/PropertyWrapper/PrimaryProxyWrapper.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\Orm\Entity\PropertyWrapper;
+
+
+use Nextras\Orm\Entity\IEntity;
+use Nextras\Orm\Entity\IEntityAwareProperty;
+use Nextras\Orm\Entity\IPropertyContainer;
+use Nextras\Orm\Entity\Reflection\EntityMetadata;
+use Nextras\Orm\Entity\Reflection\PropertyMetadata;
+use Nextras\Orm\Exception\InvalidArgumentException;
+
+
+/**
+ * @implements IEntityAwareProperty<IEntity>
+ */
+class PrimaryProxyWrapper implements IPropertyContainer, IEntityAwareProperty
+{
+	private IEntity $entity;
+	private EntityMetadata $metadata;
+
+	public function __construct(
+		PropertyMetadata $propertyMetadata, // @phpstan-ignore constructor.unusedParameter
+	)
+	{
+	}
+
+
+	public function onEntityAttach(IEntity $entity): void
+	{
+		$this->entity = $entity;
+		$this->metadata = $entity->getMetadata();
+	}
+
+
+	public function onEntityRepositoryAttach(IEntity $entity): void
+	{
+	}
+
+
+	public function setInjectedValue($value): bool
+	{
+		$this->setRawValue($value);
+		return true;
+	}
+
+
+	public function &getInjectedValue()
+	{
+		$value = $this->getRawValue();
+		return $value;
+	}
+
+
+	public function hasInjectedValue(): bool
+	{
+		$value = $this->getRawValue();
+		return isset($value);
+	}
+
+
+	public function convertToRawValue($value)
+	{
+		return $value;
+	}
+
+
+	public function setRawValue($value): void
+	{
+		if ($value === null) return;
+
+		$keys = $this->metadata->getPrimaryKey();
+
+		if (count($keys) === 1) {
+			$value = [$value];
+		} elseif (!is_array($value)) {
+			$class = get_class($this->entity);
+			throw new InvalidArgumentException("Value for $class::\$id has to be passed as array.");
+		}
+
+		if (count($keys) !== count($value)) {
+			$class = get_class($this->entity);
+			throw new InvalidArgumentException("Value for $class::\$id has insufficient number of parameters.");
+		}
+
+		foreach ($keys as $key) {
+			$this->entity->setRawValue($key, array_shift($value));
+		}
+	}
+
+
+	public function getRawValue()
+	{
+		if ($this->entity->isPersisted()) {
+			return $this->entity->getPersistedId();
+		}
+
+		$id = [];
+		$keys = $this->metadata->getPrimaryKey();
+		foreach ($keys as $key) {
+			$id[] = $this->entity->getRawValue($key);
+		}
+		if (count($keys) === 1) {
+			return $id[0];
+		} else {
+			return $id;
+		}
+	}
+}

--- a/src/Entity/Reflection/MetadataParser.php
+++ b/src/Entity/Reflection/MetadataParser.php
@@ -14,6 +14,7 @@ use Nextras\Orm\Entity\Embeddable\IEmbeddable;
 use Nextras\Orm\Entity\IEntity;
 use Nextras\Orm\Entity\IProperty;
 use Nextras\Orm\Entity\PropertyWrapper\BackedEnumWrapper;
+use Nextras\Orm\Entity\PropertyWrapper\PrimaryProxyWrapper;
 use Nextras\Orm\Exception\InvalidStateException;
 use Nextras\Orm\Exception\NotSupportedException;
 use Nextras\Orm\Relationships\HasMany;
@@ -505,8 +506,7 @@ class MetadataParser implements IMetadataParser
 		$property->isVirtual = true;
 		$property->isPrimary = true;
 		if ($property->hasGetter === null && $property->hasSetter === null) {
-			$property->hasGetter = 'getterPrimaryProxy';
-			$property->hasSetter = 'setterPrimaryProxy';
+			$property->wrapper = PrimaryProxyWrapper::class;
 		}
 	}
 


### PR DESCRIPTION
This is the first step to support property wrappers for DateTimeImmutable instances and, most importantly, also in the primary (proxied) use cases.

The next step is to abstract DateTimeImmutable handling to a property wrapper.

The next step is the introduction of the wrapper with Date (only, no time) behavior. This will be a fix for #729.