### PR TITLE
Datetime property wrapper

### DIFF
--- a/src/Collection/Functions/CompareEqualsFunction.php
+++ b/src/Collection/Functions/CompareEqualsFunction.php
@@ -4,6 +4,7 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use function count;
 use function in_array;
@@ -12,22 +13,33 @@ use function is_array;
 
 class CompareEqualsFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		if (is_array($targetValue)) {
-			return in_array($sourceValue, $targetValue, true);
+		if ($comparator === null) {
+			if (is_array($targetValue)) {
+				return in_array($sourceValue, $targetValue, strict: true);
+			} else {
+				return $sourceValue === $targetValue;
+			}
 		} else {
-			return $sourceValue === $targetValue;
+			if (is_array($targetValue)) {
+				foreach ($targetValue as $targetSubValue) {
+					if ($comparator->equals($sourceValue, $targetSubValue)) return true;
+				}
+				return false;
+			} else {
+				return $comparator->equals($sourceValue, $targetValue);
+			}
 		}
 	}
 
 
-	protected function multiEvaluateInPhp(array $values, mixed $targetValue): array
+	protected function multiEvaluateInPhp(array $values, mixed $targetValue, PropertyComparator|null $comparator): array
 	{
 		if ($targetValue === null && $values === []) {
 			return [true];
 		}
-		return parent::multiEvaluateInPhp($values, $targetValue);
+		return parent::multiEvaluateInPhp($values, $targetValue, $comparator);
 	}
 
 

--- a/src/Collection/Functions/CompareGreaterThanEqualsFunction.php
+++ b/src/Collection/Functions/CompareGreaterThanEqualsFunction.php
@@ -4,15 +4,20 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use function is_array;
 
 
 class CompareGreaterThanEqualsFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		return $sourceValue >= $targetValue;
+		if ($comparator === null) {
+			return $sourceValue >= $targetValue;
+		} else {
+			return $comparator->compare($sourceValue, $targetValue) >= 0;
+		}
 	}
 
 

--- a/src/Collection/Functions/CompareGreaterThanFunction.php
+++ b/src/Collection/Functions/CompareGreaterThanFunction.php
@@ -4,15 +4,20 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use function is_array;
 
 
 class CompareGreaterThanFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		return $sourceValue > $targetValue;
+		if ($comparator === null) {
+			return $sourceValue > $targetValue;
+		} else {
+			return $comparator->compare($sourceValue, $targetValue) === 1;
+		}
 	}
 
 

--- a/src/Collection/Functions/CompareNotEqualsFunction.php
+++ b/src/Collection/Functions/CompareNotEqualsFunction.php
@@ -4,23 +4,32 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
-use function array_combine;
-use function array_map;
 use function count;
-use function explode;
 use function in_array;
 use function is_array;
 
 
 class CompareNotEqualsFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		if (is_array($targetValue)) {
-			return !in_array($sourceValue, $targetValue, true);
+		if ($comparator === null) {
+			if (is_array($targetValue)) {
+				return !in_array($sourceValue, $targetValue, true);
+			} else {
+				return $sourceValue !== $targetValue;
+			}
 		} else {
-			return $sourceValue !== $targetValue;
+			if (is_array($targetValue)) {
+				foreach ($targetValue as $targetSubValue) {
+					if ($comparator->equals($sourceValue, $targetSubValue)) return false;
+				}
+				return true;
+			} else {
+				return !$comparator->equals($sourceValue, $targetValue);
+			}
 		}
 	}
 

--- a/src/Collection/Functions/CompareSmallerThanEqualsFunction.php
+++ b/src/Collection/Functions/CompareSmallerThanEqualsFunction.php
@@ -4,15 +4,20 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use function is_array;
 
 
 class CompareSmallerThanEqualsFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		return $sourceValue <= $targetValue;
+		if ($comparator === null) {
+			return $sourceValue <= $targetValue;
+		} else {
+			return $comparator->compare($sourceValue, $targetValue) <= 0;
+		}
 	}
 
 

--- a/src/Collection/Functions/CompareSmallerThanFunction.php
+++ b/src/Collection/Functions/CompareSmallerThanFunction.php
@@ -4,15 +4,20 @@ namespace Nextras\Orm\Collection\Functions;
 
 
 use Nextras\Orm\Collection\Functions\Result\DbalExpressionResult;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidArgumentException;
 use function is_array;
 
 
 class CompareSmallerThanFunction extends BaseCompareFunction
 {
-	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue): bool
+	protected function evaluateInPhp(mixed $sourceValue, mixed $targetValue, PropertyComparator|null $comparator): bool
 	{
-		return $sourceValue < $targetValue;
+		if ($comparator === null) {
+			return $sourceValue < $targetValue;
+		} else {
+			return $comparator->compare($sourceValue, $targetValue) === -1;
+		}
 	}
 
 

--- a/src/Collection/Helpers/ArrayCollectionHelper.php
+++ b/src/Collection/Helpers/ArrayCollectionHelper.php
@@ -4,8 +4,6 @@ namespace Nextras\Orm\Collection\Helpers;
 
 
 use Closure;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Nette\Utils\Arrays;
 use Nextras\Orm\Collection\Aggregations\Aggregator;
 use Nextras\Orm\Collection\Functions\CollectionFunction;
@@ -152,22 +150,6 @@ class ArrayCollectionHelper
 				}, $value);
 			} else {
 				$value = $property->convertToRawValue($value);
-			}
-		}
-		if (
-			(isset($propertyMetadata->types[DateTimeImmutable::class]) || isset($propertyMetadata->types[\Nextras\Dbal\Utils\DateTimeImmutable::class]))
-			&& $value !== null
-		) {
-			$converter = static function ($input): int {
-				if (!$input instanceof DateTimeInterface) {
-					$input = new DateTimeImmutable($input);
-				}
-				return $input->getTimestamp();
-			};
-			if (is_array($value)) {
-				$value = array_map($converter, $value);
-			} else {
-				$value = $converter($value);
 			}
 		}
 

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -114,6 +114,10 @@ abstract class AbstractEntity implements IEntity
 	{
 		$property = $this->metadata->getProperty($name);
 
+		if (!isset($this->validated[$name])) {
+			$this->initProperty($property, $name, initValue: false);
+		}
+
 		if ($property->wrapper !== null) {
 			if ($this->data[$name] instanceof IProperty) {
 				$this->data[$name]->setRawValue($value);
@@ -401,7 +405,7 @@ abstract class AbstractEntity implements IEntity
 	private function internalSetValue(PropertyMetadata $metadata, string $name, $value): void
 	{
 		if (!isset($this->validated[$name])) {
-			$this->initProperty($metadata, $name, /* $initValue = */ false);
+			$this->initProperty($metadata, $name, initValue: false);
 		}
 
 		$property = $this->data[$name];

--- a/src/Entity/ImmutableDataTrait.php
+++ b/src/Entity/ImmutableDataTrait.php
@@ -6,6 +6,7 @@ namespace Nextras\Orm\Entity;
 use Nextras\Orm\Entity\Reflection\EntityMetadata;
 use Nextras\Orm\Entity\Reflection\PropertyMetadata;
 use Nextras\Orm\Exception\InvalidArgumentException;
+use Nextras\Orm\Exception\InvalidPropertyValueException;
 use Nextras\Orm\Exception\InvalidStateException;
 use Nextras\Orm\Model\MetadataStorage;
 
@@ -107,8 +108,7 @@ trait ImmutableDataTrait
 	protected function validate(PropertyMetadata $metadata, string $name, &$value): void
 	{
 		if (!$metadata->isValid($value)) {
-			$class = get_class($this);
-			throw new InvalidArgumentException("Value for {$class}::\${$name} property is invalid.");
+			throw new InvalidPropertyValueException($metadata);
 		}
 	}
 

--- a/src/Entity/ImmutableDataTrait.php
+++ b/src/Entity/ImmutableDataTrait.php
@@ -77,7 +77,7 @@ trait ImmutableDataTrait
 	private function internalHasValue(PropertyMetadata $metadata, string $name): bool
 	{
 		if (!isset($this->validated[$name])) {
-			$this->initProperty($metadata, $name, false);
+			$this->initProperty($metadata, $name, initValue: false);
 		}
 
 		if ($this->data[$name] instanceof IPropertyContainer) {

--- a/src/Entity/PropertyComparator.php
+++ b/src/Entity/PropertyComparator.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\Orm\Entity;
+
+
+/**
+ * This interface can be implemented by a {@see IPropertyContainer} (a property wrapper) that encapsulates custom types.
+ */
+interface PropertyComparator
+{
+	/**
+	 * Compares its two values if they are equal. This enables equality comparison for multi-property values,
+	 * like primary-proxied $id, when {@see compare} is not allowed.
+	 */
+	function equals(mixed $a, mixed $b): bool;
+
+
+	/**
+	 * Compares its two arguments for order. Returns zero if the arguments are equal, a negative number if
+	 * the first argument is less than the second, or a positive number if the first argument is greater
+	 * than the second.
+	 */
+	function compare(mixed $a, mixed $b): int;
+}

--- a/src/Entity/PropertyWrapper/DateTimeWrapper.php
+++ b/src/Entity/PropertyWrapper/DateTimeWrapper.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\Orm\Entity\PropertyWrapper;
+
+
+use Nextras\Dbal\Utils\DateTimeImmutable;
+use Nextras\Orm\Entity\ImmutableValuePropertyWrapper;
+use Nextras\Orm\Entity\PropertyComparator;
+use Nextras\Orm\Exception\InvalidPropertyValueException;
+use Nextras\Orm\Exception\NullValueException;
+
+
+/**
+ * DateTimeImmutable property wrapper. Handles auto-conversion from string, int (unix timestamp) and DateTimeInterface
+ * instances to DateTimeImmutable (sub-)type.
+ */
+class DateTimeWrapper extends ImmutableValuePropertyWrapper implements PropertyComparator
+{
+	public function convertToRawValue(mixed $value): mixed
+	{
+		/** @var class-string<covariant DateTimeImmutable> $rawType */
+		$rawType = array_key_first($this->propertyMetadata->types);
+
+		if ($value instanceof $rawType) {
+			return $value;
+
+		} elseif ($value instanceof \DateTimeInterface) {
+			return new $rawType($value->format('c'));
+
+		} elseif ($value === null) {
+			return null;
+
+		} elseif (is_string($value)) {
+			if ($value === '') throw new InvalidPropertyValueException($this->propertyMetadata);
+
+			$tmp = new $rawType($value);
+			return $tmp->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+		} elseif (ctype_digit((string) $value)) {
+			return new $rawType("@{$value}");
+
+		} else {
+			throw new InvalidPropertyValueException($this->propertyMetadata);
+		}
+	}
+
+
+	public function convertFromRawValue($value)
+	{
+		if ($value === null && !$this->propertyMetadata->isNullable) {
+			throw new NullValueException($this->propertyMetadata);
+		}
+
+		// The string conversion from raw values is used when using {default} modifier in property definition.
+		// This string value is considered to be a raw value.
+		if (is_string($value)) {
+			if ($value === '') throw new InvalidPropertyValueException($this->propertyMetadata);
+
+			/** @var class-string<covariant DateTimeImmutable> $rawType */
+			$rawType = array_key_first($this->propertyMetadata->types);
+			$tmp = new $rawType($value);
+			return $tmp->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+		}
+
+		return $value;
+	}
+
+
+	public function setInjectedValue($value): bool
+	{
+		if ($value === null && !$this->propertyMetadata->isNullable) {
+			throw new NullValueException($this->propertyMetadata);
+		}
+		return parent::setInjectedValue($this->convertToRawValue($value));
+	}
+
+
+	public function equals(mixed $a, mixed $b): bool
+	{
+		assert($a === null || $a instanceof \DateTimeImmutable);
+		assert($b === null || $b instanceof \DateTimeImmutable);
+		return $a?->getTimestamp() === $b?->getTimestamp();
+	}
+
+
+	public function compare(mixed $a, mixed $b): int
+	{
+		assert($a === null || $a instanceof \DateTimeImmutable);
+		assert($b === null || $b instanceof \DateTimeImmutable);
+		return $a?->getTimestamp() <=> $b?->getTimestamp();
+	}
+}

--- a/src/Entity/Reflection/PropertyMetadata.php
+++ b/src/Entity/Reflection/PropertyMetadata.php
@@ -1,12 +1,5 @@
 <?php declare(strict_types = 1);
 
-/**
- * This file is part of the Nextras\Orm library.
- * This file was inspired by YetORM https://github.com/uestla/YetORM/.
- * @license    MIT
- * @link       https://github.com/nextras/orm
- */
-
 namespace Nextras\Orm\Entity\Reflection;
 
 
@@ -15,6 +8,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Nette\SmartObject;
 use Nextras\Orm\Entity\IProperty;
+use Nextras\Orm\Entity\PropertyComparator;
 use Nextras\Orm\Exception\InvalidStateException;
 use function is_subclass_of;
 
@@ -65,6 +59,15 @@ class PropertyMetadata
 			$this->wrapperPrototype = new $class($this);
 		}
 		return $this->wrapperPrototype;
+	}
+
+
+	public function getPropertyComparator(): ?PropertyComparator
+	{
+		if ($this->wrapper === null) return null;
+		$wrapper = $this->getWrapperPrototype();
+		if (!$wrapper instanceof PropertyComparator) return null;
+		return $wrapper;
 	}
 
 

--- a/src/Entity/Reflection/PropertyMetadata.php
+++ b/src/Entity/Reflection/PropertyMetadata.php
@@ -3,9 +3,6 @@
 namespace Nextras\Orm\Entity\Reflection;
 
 
-use DateTimeImmutable;
-use DateTimeInterface;
-use DateTimeZone;
 use Nette\SmartObject;
 use Nextras\Orm\Entity\IProperty;
 use Nextras\Orm\Entity\PropertyComparator;
@@ -167,24 +164,6 @@ class PropertyMetadata
 
 			} elseif ($type === 'mixed') {
 				return true;
-
-			} elseif ($rawType === DateTimeImmutable::class || is_subclass_of($rawType, DateTimeImmutable::class)) {
-				if ($value instanceof $rawType) {
-					return true;
-
-				} elseif ($value instanceof DateTimeInterface) {
-					$value = new $rawType($value->format('c'));
-					return true;
-
-				} elseif (is_string($value) && $value !== '') {
-					$tmp = new $rawType($value);
-					$value = $tmp->setTimezone(new DateTimeZone(date_default_timezone_get()));
-					return true;
-
-				} elseif (ctype_digit((string) $value)) {
-					$value = new $rawType("@{$value}");
-					return true;
-				}
 
 			} else {
 				if ($value instanceof $type) {

--- a/src/Exception/InvalidPropertyValueException.php
+++ b/src/Exception/InvalidPropertyValueException.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\Orm\Exception;
+
+
+use Nextras\Orm\Entity\Reflection\PropertyMetadata;
+
+
+class InvalidPropertyValueException extends InvalidArgumentException
+{
+	public function __construct(PropertyMetadata $propertyMetadata)
+	{
+		parent::__construct("Value for {$propertyMetadata->containerClassname}::\${$propertyMetadata->name} property is invalid.");
+	}
+}

--- a/tests/cases/unit/Entity/Reflection/PropertyMetadata.isValid().phpt
+++ b/tests/cases/unit/Entity/Reflection/PropertyMetadata.isValid().phpt
@@ -74,19 +74,16 @@ class PropertyMetadataIsValidTest extends TestCase
 		Assert::true($property->isValid($val));
 
 		$val = new DateTime();
-		Assert::true($property->isValid($val));
-		Assert::type(DateTimeImmutable::class, $val);
+		Assert::false($property->isValid($val));
 
 		$val = '';
 		Assert::false($property->isValid($val));
 
 		$val = 'now';
-		Assert::true($property->isValid($val));
-		Assert::type(DateTimeImmutable::class, $val);
+		Assert::false($property->isValid($val));
 
 		$val = time();
-		Assert::true($property->isValid($val));
-		Assert::type(DateTimeImmutable::class, $val);
+		Assert::false($property->isValid($val));
 	}
 
 


### PR DESCRIPTION
This is the second part that abstracts DateTime(Immutable) handling to a property wrapper. This also required a new abstraction for comparison (basic built-in comparison operators); therefore, the `PropertyComparator` is introduced. The most difficult thing here was making this property wrapper work when used in the primary-proxy modifier. 

Next step: introduce Date (only) property wrapper.

Refs #729.