### PR TITLE
allow extending DIRepositoryFinder with custom filtering

### DIFF
--- a/src/Bridges/NetteDI/DIRepositoryFinder.php
+++ b/src/Bridges/NetteDI/DIRepositoryFinder.php
@@ -33,8 +33,8 @@ class DIRepositoryFinder implements IRepositoryFinder
 
 	public function beforeCompile(): ?array
 	{
-		$types = $this->builder->findByType(IRepository::class);
-		$repositories = [];
+        $types = $this->findRepositories();
+        $repositories = [];
 		$repositoriesMap = [];
 		foreach ($types as $serviceName => $serviceDefinition) {
 			$serviceName = (string) $serviceName;
@@ -88,4 +88,11 @@ class DIRepositoryFinder implements IRepositoryFinder
 				'repositoryNamesMap' => $repositoriesMap,
 			]);
 	}
+
+
+    protected function findRepositories(): array
+    {
+        return $this->builder->findByType(IRepository::class);
+    }
+
 }

--- a/src/Bridges/NetteDI/FilteredDIRepositoryFinder.php
+++ b/src/Bridges/NetteDI/FilteredDIRepositoryFinder.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\Orm\Bridges\NetteDI;
+
+
+use Nette\DI\ContainerBuilder;
+use Nette\DI\Definitions\FactoryDefinition;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nextras\Orm\Exception\InvalidStateException;
+use Nextras\Orm\Model\Model;
+use Nextras\Orm\Repository\IRepository;
+use ReflectionClass;
+
+
+class FilteredDIRepositoryFinder extends DIRepositoryFinder
+{
+	private string $modelClass;
+	private ContainerBuilder $builder;
+
+
+	public function __construct(string $modelClass, ContainerBuilder $containerBuilder, OrmExtension $extension)
+	{
+		if ($modelClass === Model::class) {
+			throw new InvalidStateException('Your model has to inherit from ' . Model::class . '. Use compiler extension configuration - model key.');
+		}
+
+		$this->modelClass = $modelClass;
+		$this->builder = $containerBuilder;
+
+		parent::__construct($modelClass, $containerBuilder, $extension);
+	}
+
+
+	protected function findRepositories(): array
+	{
+		$reflection = new ReflectionClass($this->modelClass);
+		$modelClassNamespace = $reflection->getNamespaceName();
+
+		$types = $this->builder->findByType(IRepository::class);
+		$filteredTypes = [];
+
+		foreach ($types as $serviceName => $serviceDefinition) {
+			$serviceName = (string) $serviceName;
+			if ($serviceDefinition instanceof FactoryDefinition) {
+				$repositoryType = $serviceDefinition->getResultDefinition()->getType();
+
+			} elseif ($serviceDefinition instanceof ServiceDefinition || $serviceDefinition instanceof \Nette\DI\ServiceDefinition) { // @phpstan-ignore-line
+				$repositoryType = $serviceDefinition->getType();
+
+			} else {
+				$type = $serviceDefinition->getType();
+				throw new InvalidStateException(
+					"It seems DI defined repository of type '$type' is not defined as one of supported DI services.
+					Orm can only work with ServiceDefinition or FactoryDefinition services.",
+				);
+			}
+
+			if (str_starts_with($repositoryType, $modelClassNamespace)) {
+				$filteredTypes[$serviceName] = $serviceDefinition;
+			}
+		}
+
+		return $filteredTypes;
+	}
+
+}


### PR DESCRIPTION
Introduces an option to override DIRepositoryFinder in order to filter repositories registered in DIC.
Needed when ORM extension is used multiple times.

Initial discussion in the [[issue](url)](https://github.com/nextras/orm/issues/740)