### PR TITLE
Docker-compose: pgSQL: Fix tmpfs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: nextras_orm_test
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
     command: >
       -c fsync=off
       -c synchronous_commit=off


### PR DESCRIPTION
PostgreSQL 18+ změnil strukturu ukládání dat a očekává mount na `/var/lib/postgresql` místo `/var/lib/postgresql/data`.

👀 https://github.com/docker-library/postgres/pull/1259

cc @JanTvrdik 