### PR TITLE
Update documentation for setPreloadContainer method

### DIFF
--- a/src/Entity/IEntityHasPreloadContainer.php
+++ b/src/Entity/IEntityHasPreloadContainer.php
@@ -9,7 +9,7 @@ use Nextras\Orm\Collection\IEntityPreloadContainer;
 interface IEntityHasPreloadContainer
 {
 	/**
-	 * Sets the collection of entities for the loading relations at once.
+	 * Sets the collection of entities for the loading relations at once. Pass null to disable this optimization.
 	 */
 	public function setPreloadContainer(?IEntityPreloadContainer $overIterator): void;
 


### PR DESCRIPTION
Clarified the method documentation to specify that passing null disables the optimization.

Issue #785 