### PR TITLE
Fix buggy optimization in removal process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,6 +201,7 @@ jobs:
           find tests -name \*.log -exec echo "--- {}" \; -exec cat {} \; -exec echo \; -exec echo \;
 
       - name: Send coverage report
+        continue-on-error: true
         env:
           COVERALLS_PARALLEL: "true"
           COVERALLS_FLAG_NAME: run-${{ matrix.php-version }}

--- a/tests/cases/integration/Relationships/relationships.manyHasMany.collection.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.collection.phpt
@@ -325,7 +325,7 @@ class RelationshipsManyHasManyCollectionTest extends DataTestCase
 
 			$tag2 = $this->orm->tags->getByIdChecked(2); // SELECT
 
-			// 4 SELECTS: all main non-null relationships (books_x_tags, books, publishers_x_tags, tag_followers)
+			// 6 SELECTS: all relationships (tag_followers, books_x_tags, tags (???), publishers_x_tags, authors)
 			// TRANSACTION BEGIN
 			// 4 DELETES: 2 books_x_tags, tag_follower, tag
 			$this->orm->tags->remove($tag2);
@@ -333,7 +333,7 @@ class RelationshipsManyHasManyCollectionTest extends DataTestCase
 		});
 
 		if ($queries !== null) {
-			Assert::count(10, $queries);
+			Assert::count(12, $queries);
 		}
 	}
 

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.collection.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.collection.phpt
@@ -368,7 +368,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 
 			$book2 = $this->orm->books->getByIdChecked(2); // SELECT book
 
-			// 2 SELECTS: all rest main non-null relationships (books_x_tags, tags)
+			// 5 SELECTS: all relationships (author, books_x_tags, tags, books.next_part, publisher)
 			// TRANSACTION BEGIN
 			// 2 DELETES: books_x_tags, book
 			$this->orm->books->remove($book2);
@@ -376,7 +376,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 		});
 
 		if ($queries !== null) {
-			Assert::count(6, $queries);
+			Assert::count(9, $queries);
 		}
 	}
 
@@ -390,7 +390,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 			$book2->getValue('author'); // SELECT
 			Assert::count(1, $this->books->getEntitiesForPersistence());
 
-			// 2 SELECTS: all rest main non-null relationships (books_x_tags, tags)
+			// 4 SELECTS: all rest relationships (books_x_tags, tags, books.next_part, publisher)
 			// TRANSACTION BEGIN
 			// 2 DELETES: books_x_tags, book
 			$this->orm->books->remove($book2);
@@ -398,7 +398,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 		});
 
 		if ($queries !== null) {
-			Assert::count(7, $queries);
+			Assert::count(9, $queries);
 		}
 	}
 

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.remove.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.remove.phpt
@@ -12,6 +12,8 @@ use Nextras\Orm\Exception\InvalidStateException;
 use NextrasTests\Orm\Author;
 use NextrasTests\Orm\Book;
 use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Photo;
+use NextrasTests\Orm\PhotoAlbum;
 use Tester\Assert;
 
 
@@ -105,6 +107,27 @@ class RelationshipOneHasManyRemoveTest extends DataTestCase
 
 		$this->orm->authors->removeAndFlush($author);
 		Assert::false($author->isPersisted());
+	}
+
+
+	public function testManualRemove(): void
+	{
+		$origPhoto = new Photo();
+		$origPhoto->title = 'Photo';
+		$origPhoto->album = new PhotoAlbum();
+		$origPhoto->album->title = 'Album';
+		$this->orm->photos->persistAndFlush($origPhoto);
+		$albumId = $origPhoto->album->id;
+
+		$this->orm->clear();
+
+		$album = $this->orm->photoAlbums->getByIdChecked($albumId);
+		foreach ($album->photos as $photo) {
+			$this->orm->photos->remove($photo);
+		}
+		$this->orm->photoAlbums->removeAndFlush($album);
+
+		Assert::false($album->isPersisted());
 	}
 }
 

--- a/tests/db/pgsql-data.sql
+++ b/tests/db/pgsql-data.sql
@@ -11,6 +11,8 @@ TRUNCATE users_x_users CASCADE;
 TRUNCATE user_stats CASCADE;
 TRUNCATE users CASCADE;
 TRUNCATE logs CASCADE;
+TRUNCATE photos CASCADE;
+TRUNCATE photo_albums CASCADE;
 
 
 INSERT INTO "authors" ("id", "name", "web", "born_on") VALUES (1, 'Writer 1', 'http://example.com/1', NULL);

--- a/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityPreloadContainerTest_testWithEntityWithInvalidRelationshipState.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityPreloadContainerTest_testWithEntityWithInvalidRelationshipState.sql
@@ -1,5 +1,7 @@
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 1;
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."author_id" IN (1);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (1);
 START TRANSACTION;
 DELETE FROM "tag_followers" WHERE "author_id" = 1 AND "tag_id" = 1;
-SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (1, 3);
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (3);

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipManyHasManyTest_testCountAfterRemoveAndFlushAndCount.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipManyHasManyTest_testCountAfterRemoveAndFlushAndCount.sql
@@ -31,6 +31,7 @@ WHERE
   "books_x_tags"."book_id" IN (5);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (4);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((5, 4));
 DELETE FROM "books" WHERE "id" = 5;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyCompositePkTest_testRemoveHasMany.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyCompositePkTest_testRemoveHasMany.sql
@@ -1,7 +1,8 @@
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE ("tag_followers"."tag_id" = 3) AND ("tag_followers"."author_id" = 1);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (3);
 START TRANSACTION;
 DELETE FROM "tag_followers" WHERE "author_id" = 1 AND "tag_id" = 3;
 COMMIT;
-SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 1;
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."author_id" IN (1);
 SELECT "author_id", COUNT(DISTINCT "tag_followers"."tag_id") as "count" FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."author_id" IN (1) GROUP BY "author_id";

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveAllTest_testRemoveAllItems.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveAllTest_testRemoveAllItems.sql
@@ -7,6 +7,7 @@ INSERT INTO "tag_followers" ("created_at", "author_id", "tag_id") VALUES ('2021-
 COMMIT;
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."author_id" IN (3);
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE (NOT (("tag_followers"."author_id", "tag_followers"."tag_id") IN ((3, 4)))) AND ("tag_followers"."author_id" IN (3));
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (4);
 START TRANSACTION;
 DELETE FROM "tag_followers" WHERE "author_id" = 3 AND "tag_id" = 4;
 COMMIT;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testManualRemove.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testManualRemove.sql
@@ -1,0 +1,15 @@
+START TRANSACTION;
+INSERT INTO "photo_albums" ("title", "preview_id") VALUES ('Album', NULL);
+SELECT CURRVAL('public.photo_albums_id_seq');
+INSERT INTO "photos" ("title", "album_id") VALUES ('Photo', 1);
+SELECT CURRVAL('public.photos_id_seq');
+COMMIT;
+SELECT "photo_albums".* FROM "photo_albums" AS "photo_albums" WHERE "photo_albums"."id" = 1;
+SELECT "photos".* FROM "photos" AS "photos" WHERE "photos"."album_id" IN (1);
+SELECT "photo_albums".* FROM "photo_albums" AS "photo_albums" WHERE "photo_albums"."id" IN (1);
+SELECT "photo_albums".* FROM "photo_albums" AS "photo_albums" WHERE "photo_albums"."preview_id" IN (1);
+START TRANSACTION;
+DELETE FROM "photos" WHERE "id" = 1;
+SELECT "photos".* FROM "photos" AS "photos" WHERE "photos"."album_id" IN (1);
+DELETE FROM "photo_albums" WHERE "id" = 1;
+COMMIT;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveCollection.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveCollection.sql
@@ -17,6 +17,7 @@ FROM
 WHERE
   "books_x_tags"."book_id" IN (5);
 
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);
 START TRANSACTION;
 DELETE FROM "books" WHERE "id" = 5;
 COMMIT;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveCollectionAndParent.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveCollectionAndParent.sql
@@ -17,6 +17,7 @@ FROM
 WHERE
   "books_x_tags"."book_id" IN (5);
 
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);
 START TRANSACTION;
 DELETE FROM "books" WHERE "id" = 5;
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."favorite_author_id" IN (3);

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveOrphanBehavior.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyRemoveTest_testRemoveOrphanBehavior.sql
@@ -1,5 +1,6 @@
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 2;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."author_id" IN (2) ORDER BY "books"."id" DESC;
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -13,6 +14,9 @@ WHERE
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (3);
 SELECT "books".* FROM "books" AS "books" WHERE "books"."id" IN (3);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (4, 3);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (1, 3);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -25,11 +29,11 @@ WHERE
   "books_x_tags"."book_id" IN (3);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (3);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (3);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((3, 3));
 DELETE FROM "books" WHERE "id" = 4;
 DELETE FROM "books" WHERE "id" = 3;
 COMMIT;
 SELECT "author_id", COUNT(DISTINCT "books"."id") as "count" FROM "books" AS "books" WHERE "books"."author_id" IN (2) GROUP BY "author_id";
-SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" = 1;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."publisher_id" IN (1);

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyTest_testCountAfterRemoveAndFlushAndCount.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyTest_testCountAfterRemoveAndFlushAndCount.sql
@@ -18,6 +18,7 @@ FROM
 WHERE
   "books_x_tags"."book_id" IN (5);
 
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);
 START TRANSACTION;
 DELETE FROM "books" WHERE "id" = 5;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."author_id" IN (3) ORDER BY "books"."id" DESC;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyTest_testRawValue.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasManyTest_testRawValue.sql
@@ -1,5 +1,7 @@
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 1;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."author_id" IN (1) ORDER BY "books"."id" DESC;
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -12,14 +14,12 @@ WHERE
   "books_x_tags"."book_id" IN (1);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (1, 2);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (1);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (1);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((1, 1), (1, 2));
 DELETE FROM "books" WHERE "id" = 1;
-SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" = 1;
-SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
-SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
-SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (2, 1);
-SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (2, 1);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."author_id" IN (1) ORDER BY "books"."id" DESC;
 INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Test book', 1, NULL, NULL, NULL, 1, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
 SELECT CURRVAL('public.books_id_seq');
 COMMIT;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testCascadeRemove.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testCascadeRemove.sql
@@ -6,6 +6,8 @@ UPDATE "books" SET "ean_id" = 1 WHERE "id" = 1;
 COMMIT;
 SELECT "eans".* FROM "eans" AS "eans" WHERE "eans"."id" = 1;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."ean_id" IN (1);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -18,6 +20,8 @@ WHERE
   "books_x_tags"."book_id" IN (1);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (1, 2);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (1);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (1);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((1, 1), (1, 2));
 DELETE FROM "books" WHERE "id" = 1;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testCascadeRemoveWithNull.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testCascadeRemoveWithNull.sql
@@ -2,6 +2,7 @@ START TRANSACTION;
 INSERT INTO "eans" ("code", "type") VALUES ('1234', 2);
 SELECT CURRVAL('public.eans_id_seq');
 COMMIT;
+SELECT "books".* FROM "books" AS "books" WHERE "books"."ean_id" IN (1);
 START TRANSACTION;
 DELETE FROM "eans" WHERE "id" = 1;
 COMMIT;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsManyHasManyCollectionTest_testRemoveA.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsManyHasManyCollectionTest_testRemoveA.sql
@@ -24,6 +24,8 @@ WHERE
   "publishers_x_tags"."tag_id" IN (2);
 
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."tag_id" IN (2);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (2);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((1, 2));
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((2, 2));

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsOneHasManyCollectionTest_testRemoveB.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsOneHasManyCollectionTest_testRemoveB.sql
@@ -2,6 +2,7 @@ SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publ
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 1;
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 2;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."id" = 2;
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (1);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -14,6 +15,8 @@ WHERE
   "books_x_tags"."book_id" IN (2);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (2, 3);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (2);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (2);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((2, 2), (2, 3));
 DELETE FROM "books" WHERE "id" = 2;

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsOneHasManyCollectionTest_testRemoveC.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipsOneHasManyCollectionTest_testRemoveC.sql
@@ -15,6 +15,8 @@ WHERE
   "books_x_tags"."book_id" IN (2);
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (2, 3);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (2);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (2);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((2, 2), (2, 3));
 DELETE FROM "books" WHERE "id" = 2;

--- a/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testBasicCascadeRemove.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testBasicCascadeRemove.sql
@@ -8,6 +8,8 @@ COMMIT;
 SELECT "books".* FROM "books" AS "books" WHERE "books"."id" = 3;
 SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."favorite_author_id" IN (2);
 SELECT "books".* FROM "books" AS "books" WHERE "books"."author_id" IN (2) ORDER BY "books"."id" DESC;
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
 SELECT
   "books_x_tags"."tag_id",
   "books_x_tags"."book_id"
@@ -21,8 +23,12 @@ WHERE
 
 SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (3);
 SELECT "books".* FROM "books" AS "books" WHERE "books"."id" IN (3);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (4, 3);
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" IN (1, 3);
 SELECT "books".* FROM "books" AS "books" WHERE "books"."translator_id" IN (2);
 SELECT "tag_followers".* FROM "tag_followers" AS "tag_followers" WHERE "tag_followers"."author_id" IN (2);
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" IN (2);
+SELECT "tags".* FROM "tags" AS "tags" WHERE "tags"."id" IN (2);
 START TRANSACTION;
 DELETE FROM "books_x_tags" WHERE ("book_id", "tag_id") IN ((3, 3));
 UPDATE "books" SET "translator_id" = NULL WHERE "id" = 5;

--- a/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testCascadeWithOneHasOneRelationship.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testCascadeWithOneHasOneRelationship.sql
@@ -19,6 +19,7 @@ FROM
 WHERE
   "books_x_tags"."book_id" IN (5);
 
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);
 START TRANSACTION;
 DELETE FROM "books" WHERE "id" = 5;
 DELETE FROM "eans" WHERE "id" = 1;

--- a/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testSingleTableInheritance.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Repository/RepositoryCascadeRemoveTest_testSingleTableInheritance.sql
@@ -1,6 +1,8 @@
 SELECT "contents".* FROM "contents" AS "contents" WHERE "contents"."id" = 2;
 SELECT "contents".* FROM "contents" AS "contents" WHERE "contents"."id" IN (1);
 SELECT "contents".* FROM "contents" AS "contents" WHERE "contents"."thread_id" IN (1);
+SELECT "contents".* FROM "contents" AS "contents" WHERE "contents"."id" IN (1);
+SELECT "books".* FROM "books" AS "books" WHERE "books"."thread_id" IN (1);
 START TRANSACTION;
 DELETE FROM "contents" WHERE "id" = 2;
 DELETE FROM "contents" WHERE "id" = 3;


### PR DESCRIPTION
fix pgsql test data truncate

add failing testcase for data removal

Revert "model: optimize relationship traversal"

This reverts commit 17304b959fb7e2509b00ce0fc9f1de190f7c0ade.