### PR TITLE
Fix: EntityCreator::fill() triggers premature initialization of non-nullable wrapped properties

### DIFF
--- a/src/TestHelper/EntityCreator.php
+++ b/src/TestHelper/EntityCreator.php
@@ -55,7 +55,13 @@ class EntityCreator
 				$value = $this->random($property);
 			}
 
-			if ($property->wrapper !== null) {
+			if (
+				$property->relationship !== null
+				&& in_array($property->relationship->type, [
+					PropertyRelationshipMetadata::ONE_HAS_MANY,
+					PropertyRelationshipMetadata::MANY_HAS_MANY,
+				], true)
+			) {
 				$realProperty = $entity->getProperty($key);
 				if ($realProperty instanceof IRelationshipCollection) {
 					$realProperty->set($value);


### PR DESCRIPTION
## Problem

When using `EntityCreator::create()` (or `fill()`) to create a test entity, properties wrapped by non-relationship wrappers (e.g. `DateTimeWrapper`) get prematurely initialized with `null`, which throws `NullValueException` for non-nullable properties — even when a valid value is being passed in `$params`.

## Reproduction

Given an entity with a non-nullable `DateTimeImmutable` property:

```php
/**
 * @property DateTimeImmutable $createdAt
 */
class MyEntity extends Entity {}
```

Calling:

```php
$creator->create(MyEntity::class, [
    'createdAt' => new DateTimeImmutable(),
]);
```

throws:

```
Nextras\Orm\Exception\NullValueException: Property MyEntity::$createdAt is not nullable.
```

## Root cause

In `EntityCreator::fill()`, for every property with a wrapper, `$entity->getProperty($key)` is called to detect whether the wrapper is an `IRelationshipCollection`:

```php
if ($property->wrapper !== null) {
    $realProperty = $entity->getProperty($key);
    if ($realProperty instanceof IRelationshipCollection) {
        $realProperty->set($value);
        continue;
    }
}

$entity->setReadOnlyValue($key, $value);
```

`getProperty()` calls `initProperty()`, which calls `setRawValue(null)` on the wrapper since no value has been set yet. For wrappers like `DateTimeWrapper`, `convertFromRawValue(null)` throws `NullValueException` for non-nullable properties — before the actual value from `$params` ever reaches the entity.

This affects all non-nullable properties using a value wrapper (date/time, custom value wrappers, etc.) when used with `EntityCreator`.

## Fix

Only call `getProperty()` when the property is a collection relationship (`ONE_HAS_MANY` or `MANY_HAS_MANY`) — those are the only relationships using `IRelationshipCollection`. The relationship type is available on `$property->relationship->type` from metadata, so we don't need to instantiate the wrapper to know whether to call `set()` on it.

```php
if (
    $property->relationship !== null
    && in_array($property->relationship->type, [
        PropertyRelationshipMetadata::ONE_HAS_MANY,
        PropertyRelationshipMetadata::MANY_HAS_MANY,
    ], true)
) {
    $realProperty = $entity->getProperty($key);
    if ($realProperty instanceof IRelationshipCollection) {
        $realProperty->set($value);
        continue;
    }
}

$entity->setReadOnlyValue($key, $value);
```

For all other wrapped properties, `setReadOnlyValue($key, $value)` is called directly with the user-supplied value, which goes through normal initialization with the correct value rather than `null`.

## Notes

- Behavior for relationship collections is unchanged.
- For non-collection wrapped properties (incl. `DateTimeWrapper`, `EnumWrapper`, custom `ImmutableValuePropertyWrapper` subclasses), the value supplied in `$params` is now used to initialize the property directly, instead of being preceded by an aborted `null`-init.
- Detected on PHP 8.5 / nextras/orm v5.1, but the bug is version-agnostic.
