### PR TITLE
fix various issues

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -231,8 +231,13 @@ abstract class AbstractEntity implements IEntity
 		$persistedId = $this->persistedId;
 		$isAttached = $this->isAttached();
 		foreach ($this->getMetadata()->getProperties() as $name => $metadataProperty) {
-			// getValue loads data & checks for not null values
-			if ($this->hasValue($name) && is_object($this->data[$name])) {
+			// ensure the property wrapper is initialized; it must be cloned even when it holds
+			// a null value (nullable m:1/1:1, nullable DateTime, embeddable) — otherwise the
+			// wrapper object stays shared with the original entity and still points at the
+			// original as its parent. hasValue() cannot be used as the guard here because it
+			// returns false for an initialized wrapper holding null.
+			$this->hasValue($name);
+			if (is_object($this->data[$name])) {
 				if ($this->data[$name] instanceof IRelationshipCollection) {
 					$data = iterator_to_array($this->data[$name]->toCollection());
 					$this->data['id'] = null;

--- a/src/Entity/Reflection/MetadataParser.php
+++ b/src/Entity/Reflection/MetadataParser.php
@@ -175,36 +175,53 @@ class MetadataParser implements IMetadataParser
 					$file = $reflectionTrait->getFileName();
 					if ($file !== false) $fileDependencies[] = $file;
 					$this->currentReflection = $reflectionTrait;
-					$this->classPropertiesCache[$traitName] = $this->parseAnnotations($reflectionTrait, $methods);
+					$this->classPropertiesCache[$traitName] = $this->parseAnnotations($reflectionTrait);
 				}
 
 				$reflection = new ReflectionClass($class);
 				$file = $reflection->getFileName();
 				if ($file !== false) $fileDependencies[] = $file;
 				$this->currentReflection = $reflection;
-				$this->classPropertiesCache[$class] = $this->parseAnnotations($reflection, $methods);
+				$this->classPropertiesCache[$class] = $this->parseAnnotations($reflection);
 			}
 
 			$traits = class_uses($class);
 			foreach ($traits !== false ? $traits : [] as $traitName) {
 				foreach ($this->classPropertiesCache[$traitName] as $name => $property) {
-					$this->metadata->setProperty($name, $property);
+					$this->metadata->setProperty($name, $this->createEntityProperty($property, $methods));
 				}
 			}
 
 			foreach ($this->classPropertiesCache[$class] as $name => $property) {
-				$this->metadata->setProperty($name, $property);
+				$this->metadata->setProperty($name, $this->createEntityProperty($property, $methods));
 			}
 		}
 	}
 
 
 	/**
-	 * @param ReflectionClass<object> $reflection
+	 * Clones a cached property metadata for a concrete entity and resolves its getters/setters.
+	 *
+	 * The parsed property metadata is cached per defining class/trait and therefore shared by all
+	 * entities that share that class/trait. Getters/setters depend on the concrete entity's method
+	 * list, so they must be resolved per entity on a private copy — otherwise the resolution baked
+	 * in for the first parsed entity would contaminate its siblings.
+	 *
 	 * @param array<string, true> $methods
+	 */
+	protected function createEntityProperty(PropertyMetadata $property, array $methods): PropertyMetadata
+	{
+		$property = clone $property;
+		$this->processPropertyGettersSetters($property, $methods);
+		return $property;
+	}
+
+
+	/**
+	 * @param ReflectionClass<object> $reflection
 	 * @return array<string, PropertyMetadata>
 	 */
-	protected function parseAnnotations(ReflectionClass $reflection, array $methods): array
+	protected function parseAnnotations(ReflectionClass $reflection): array
 	{
 		$docComment = $reflection->getDocComment();
 		if ($docComment === false) return [];
@@ -214,28 +231,24 @@ class MetadataParser implements IMetadataParser
 
 		$properties = [];
 		foreach ($phpDocNode->getPropertyTagValues() as $propertyTagValue) {
-			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), $methods, isReadonly: false);
+			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), isReadonly: false);
 			$properties[$property->name] = $property;
 		}
 		foreach ($phpDocNode->getPropertyWriteTagValues() as $propertyTagValue) {
-			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), $methods, isReadonly: false);
+			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), isReadonly: false);
 			$properties[$property->name] = $property;
 		}
 		foreach ($phpDocNode->getPropertyReadTagValues() as $propertyTagValue) {
-			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), $methods, isReadonly: true);
+			$property = $this->parseProperty($propertyTagValue, $reflection->getName(), isReadonly: true);
 			$properties[$property->name] = $property;
 		}
 		return $properties;
 	}
 
 
-	/**
-	 * @param array<string, true> $methods
-	 */
 	protected function parseProperty(
 		PropertyTagValueNode $propertyNode,
 		string $containerClassName,
-		array $methods,
 		bool $isReadonly,
 	): PropertyMetadata
 	{
@@ -246,7 +259,6 @@ class MetadataParser implements IMetadataParser
 
 		$this->parseAnnotationTypes($property, $propertyNode->type);
 		$this->parseAnnotationValue($property, $propertyNode->description);
-		$this->processPropertyGettersSetters($property, $methods);
 		$this->processDefaultPropertyWrappers($property);
 
 		foreach ($this->extensions as $extension) {

--- a/src/Entity/Reflection/PropertyMetadata.php
+++ b/src/Entity/Reflection/PropertyMetadata.php
@@ -46,6 +46,14 @@ class PropertyMetadata
 	}
 
 
+	public function __clone()
+	{
+		// the lazily-created wrapper prototype is bound to the original metadata instance,
+		// so it must be rebuilt for the clone
+		$this->wrapperPrototype = null;
+	}
+
+
 	public function getWrapperPrototype(): IProperty
 	{
 		if ($this->wrapperPrototype === null) {

--- a/src/Relationships/HasOne.php
+++ b/src/Relationships/HasOne.php
@@ -381,7 +381,9 @@ abstract class HasOne implements IRelationshipContainer
 		if ($isImmediate || $entity === null) {
 			return $this->tracked;
 		} else {
-			return $this->tracked + [$entity];
+			// $this->tracked is a list, so the "+" operator would drop $entity (both use key 0);
+			// array_merge re-indexes and keeps the current entity in the cascade.
+			return array_merge($this->tracked, [$entity]);
 		}
 	}
 

--- a/tests/cases/integration/Entity/entity.cloning.phpt
+++ b/tests/cases/integration/Entity/entity.cloning.phpt
@@ -8,9 +8,12 @@
 namespace NextrasTests\Orm\Integration\Entity;
 
 
+use DateTimeImmutable;
 use NextrasTests\Orm\Author;
 use NextrasTests\Orm\Book;
+use NextrasTests\Orm\Currency;
 use NextrasTests\Orm\DataTestCase;
+use NextrasTests\Orm\Money;
 use NextrasTests\Orm\Publisher;
 use NextrasTests\Orm\Tag;
 use Tester\Assert;
@@ -66,6 +69,61 @@ class EntityCloningTest extends DataTestCase
 
 		Assert::same($author, $newBook->author);
 		Assert::same([$tag1, $tag2, $tag3], iterator_to_array($newBook->tags));
+	}
+
+
+	public function testCloningNullableRelationship(): void
+	{
+		$book = $this->createBookWithNulls();
+		Assert::null($book->translator); // initializes the wrapper holding null
+
+		$newBook = clone $book;
+		$translator = $this->e(Author::class, ['name' => 'Translator']);
+		$newBook->translator = $translator;
+
+		// the original entity must not be affected by changes to the clone
+		Assert::null($book->translator);
+		Assert::false($book->isModified('translator'));
+		Assert::same($translator, $newBook->translator);
+	}
+
+
+	public function testCloningNullableDateTime(): void
+	{
+		$book = $this->createBookWithNulls();
+		Assert::null($book->printedAt); // initializes the wrapper holding null
+
+		$newBook = clone $book;
+		$newBook->printedAt = new DateTimeImmutable('2020-01-01 00:00:00');
+
+		// the original entity must not be affected by changes to the clone
+		Assert::null($book->printedAt);
+		Assert::notNull($newBook->printedAt);
+		Assert::same('2020-01-01', $newBook->printedAt->format('Y-m-d'));
+	}
+
+
+	public function testCloningNullableEmbeddable(): void
+	{
+		$book = $this->createBookWithNulls();
+		Assert::null($book->price); // initializes the embeddable wrapper holding null
+
+		$newBook = clone $book;
+		$newBook->price = new Money(100, Currency::CZK);
+
+		// the original entity must not be affected by changes to the clone
+		Assert::null($book->price);
+		Assert::same(100, $newBook->price->cents);
+	}
+
+
+	private function createBookWithNulls(): Book
+	{
+		$author = $this->e(Author::class, ['name' => 'Author']);
+		$publisher = $this->e(Publisher::class, ['name' => 'Publisher']);
+		$book = $this->e(Book::class, ['author' => $author, 'title' => 'Book', 'publisher' => $publisher]);
+		$this->orm->books->persistAndFlush($book);
+		return $book;
 	}
 
 }

--- a/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasOne.phpt
@@ -164,6 +164,39 @@ class RelationshipOneHasOneTest extends DataTestCase
 	}
 
 
+	public function testPersistNonMainSideReplacementWithNewEntity(): void
+	{
+		$this->orm->clear();
+
+		$book1 = new Book();
+		$book1->author = $this->orm->authors->getByIdChecked(1);
+		$book1->title = 'Games of Thrones I';
+		$book1->publisher = 1;
+
+		$ean = new Ean();
+		$ean->code = '1234';
+		$ean->book = $book1;
+		$this->orm->eans->persistAndFlush($ean);
+
+		// replace the persisted book with a brand-new (unpersisted) one on the non-main side;
+		// tracked now holds the old book, so getEntitiesForPersistence must still return the
+		// new current book — otherwise it is silently dropped from the cascade (lost insert).
+		// A different author & publisher ensures the new book is reachable *only* through this
+		// relationship (no shared reverse collection re-adds it to the cascade).
+		$book2 = new Book();
+		$book2->author = $this->orm->authors->getByIdChecked(2);
+		$book2->title = 'Games of Thrones II';
+		$book2->publisher = 2;
+		$ean->book = $book2;
+		$this->orm->eans->persistAndFlush($ean);
+
+		Assert::true($book2->isPersisted());
+		Assert::same($book2, $ean->book);
+		Assert::same($ean, $book2->ean);
+		Assert::null($book1->ean);
+	}
+
+
 	public function testUpdateRelationshipWithNULL(): void
 	{
 		$book = new Book();

--- a/tests/cases/unit/Entity/Reflection/MetadataParser.gettersSettersCache().phpt
+++ b/tests/cases/unit/Entity/Reflection/MetadataParser.gettersSettersCache().phpt
@@ -1,0 +1,101 @@
+<?php declare(strict_types = 1);
+
+/**
+ * @testCase
+ */
+
+namespace NextrasTests\Orm\Entity\Reflection;
+
+
+use Nextras\Orm\Entity\Entity;
+use Nextras\Orm\Entity\Reflection\MetadataParser;
+use NextrasTests\Orm\TestCase;
+use Tester\Assert;
+
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+
+/**
+ * @property int    $id   {primary}
+ * @property string $name
+ */
+abstract class SharedBaseEntity extends Entity
+{
+}
+
+
+class GetterChildEntity extends SharedBaseEntity
+{
+	protected function getterName(): string
+	{
+		return 'getter';
+	}
+}
+
+
+class SetterChildEntity extends SharedBaseEntity
+{
+	protected function setterName(string $value): string
+	{
+		return $value;
+	}
+}
+
+
+class PlainChildEntity extends SharedBaseEntity
+{
+}
+
+
+class MetadataParserGettersSettersCacheTest extends TestCase
+{
+	/**
+	 * Entities that share a defining class/trait share a parser cache entry for its properties.
+	 * Getters/setters depend on the concrete entity's method list and therefore must be resolved
+	 * per entity — the resolution for the first parsed entity must not leak into its siblings.
+	 */
+	public function testGettersSettersResolvedPerEntity(): void
+	{
+		$dependencies = [];
+		$parser = new MetadataParser([]);
+
+		// parse the entity WITH a getter first, so a shared cache would bake it in
+		$getterMeta = $parser->parseMetadata(GetterChildEntity::class, $dependencies);
+		$setterMeta = $parser->parseMetadata(SetterChildEntity::class, $dependencies);
+		$plainMeta = $parser->parseMetadata(PlainChildEntity::class, $dependencies);
+
+		Assert::same('gettername', $getterMeta->getProperty('name')->hasGetter);
+		Assert::null($getterMeta->getProperty('name')->hasSetter);
+
+		Assert::null($setterMeta->getProperty('name')->hasGetter);
+		Assert::same('settername', $setterMeta->getProperty('name')->hasSetter);
+
+		// the plain entity must not inherit the sibling's getter/setter
+		Assert::null($plainMeta->getProperty('name')->hasGetter);
+		Assert::null($plainMeta->getProperty('name')->hasSetter);
+
+		// sibling entities must not share the same PropertyMetadata instance
+		Assert::notSame($getterMeta->getProperty('name'), $plainMeta->getProperty('name'));
+	}
+
+
+	/**
+	 * The same must hold regardless of parse order (plain entity parsed first).
+	 */
+	public function testGettersSettersResolvedPerEntityReversedOrder(): void
+	{
+		$dependencies = [];
+		$parser = new MetadataParser([]);
+
+		$plainMeta = $parser->parseMetadata(PlainChildEntity::class, $dependencies);
+		$getterMeta = $parser->parseMetadata(GetterChildEntity::class, $dependencies);
+
+		Assert::null($plainMeta->getProperty('name')->hasGetter);
+		Assert::same('gettername', $getterMeta->getProperty('name')->hasGetter);
+	}
+}
+
+
+$test = new MetadataParserGettersSettersCacheTest();
+$test->run();

--- a/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableDateTime.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableDateTime.sql
@@ -1,0 +1,20 @@
+START TRANSACTION;
+INSERT INTO "public"."authors" ("name", "born_on", "web", "favorite_author_id") VALUES ('Author', '2021-03-21'::date, 'http://www.example.com', NULL);
+SELECT CURRVAL('public.authors_id_seq');
+INSERT INTO "publishers" ("name") VALUES ('Publisher');
+SELECT CURRVAL('public.publishers_publisher_id_seq');
+INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Book', 3, NULL, NULL, NULL, 4, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT CURRVAL('public.books_id_seq');
+COMMIT;
+SELECT
+  "books_x_tags"."tag_id",
+  "books_x_tags"."book_id"
+FROM
+  "tags" AS "tags"
+  LEFT JOIN "books_x_tags" AS "books_x_tags" ON (
+    "books_x_tags"."tag_id" = "tags"."id"
+  )
+WHERE
+  "books_x_tags"."book_id" IN (5);
+
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);

--- a/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableEmbeddable.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableEmbeddable.sql
@@ -1,0 +1,20 @@
+START TRANSACTION;
+INSERT INTO "public"."authors" ("name", "born_on", "web", "favorite_author_id") VALUES ('Author', '2021-03-21'::date, 'http://www.example.com', NULL);
+SELECT CURRVAL('public.authors_id_seq');
+INSERT INTO "publishers" ("name") VALUES ('Publisher');
+SELECT CURRVAL('public.publishers_publisher_id_seq');
+INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Book', 3, NULL, NULL, NULL, 4, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT CURRVAL('public.books_id_seq');
+COMMIT;
+SELECT
+  "books_x_tags"."tag_id",
+  "books_x_tags"."book_id"
+FROM
+  "tags" AS "tags"
+  LEFT JOIN "books_x_tags" AS "books_x_tags" ON (
+    "books_x_tags"."tag_id" = "tags"."id"
+  )
+WHERE
+  "books_x_tags"."book_id" IN (5);
+
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);

--- a/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableRelationship.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Entity/EntityCloningTest_testCloningNullableRelationship.sql
@@ -1,0 +1,20 @@
+START TRANSACTION;
+INSERT INTO "public"."authors" ("name", "born_on", "web", "favorite_author_id") VALUES ('Author', '2021-03-21'::date, 'http://www.example.com', NULL);
+SELECT CURRVAL('public.authors_id_seq');
+INSERT INTO "publishers" ("name") VALUES ('Publisher');
+SELECT CURRVAL('public.publishers_publisher_id_seq');
+INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Book', 3, NULL, NULL, NULL, 4, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT CURRVAL('public.books_id_seq');
+COMMIT;
+SELECT
+  "books_x_tags"."tag_id",
+  "books_x_tags"."book_id"
+FROM
+  "tags" AS "tags"
+  LEFT JOIN "books_x_tags" AS "books_x_tags" ON (
+    "books_x_tags"."tag_id" = "tags"."id"
+  )
+WHERE
+  "books_x_tags"."book_id" IN (5);
+
+SELECT "books".* FROM "books" AS "books" WHERE "books"."next_part" IN (5);

--- a/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testPersistNonMainSideReplacementWithNewEntity.sql
+++ b/tests/sqls/NextrasTests/Orm/Integration/Relationships/RelationshipOneHasOneTest_testPersistNonMainSideReplacementWithNewEntity.sql
@@ -1,0 +1,15 @@
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 1;
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" = 1;
+START TRANSACTION;
+INSERT INTO "eans" ("code", "type") VALUES ('1234', 2);
+SELECT CURRVAL('public.eans_id_seq');
+INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Games of Thrones I', 1, NULL, NULL, 1, 1, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT CURRVAL('public.books_id_seq');
+COMMIT;
+SELECT "authors".* FROM "public"."authors" AS "authors" WHERE "authors"."id" = 2;
+SELECT "publishers".* FROM "publishers" AS "publishers" WHERE "publishers"."publisher_id" = 2;
+START TRANSACTION;
+UPDATE "books" SET "ean_id" = NULL WHERE "id" = 5;
+INSERT INTO "books" ("title", "author_id", "translator_id", "next_part", "ean_id", "publisher_id", "genre", "published_at", "printed_at", "thread_id", "price", "price_currency", "orig_price_cents", "orig_price_currency") VALUES ('Games of Thrones II', 2, NULL, NULL, 1, 2, 'fantasy', '2021-12-31 23:59:59.000000'::timestamp, NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT CURRVAL('public.books_id_seq');
+COMMIT;


### PR DESCRIPTION
fix: clone entity property wrappers holding a null value

AbstractEntity::__clone guarded the clone loop on hasValue(), which is
false for an initialized wrapper whose injected value is null (nullable
m:1/1:1, nullable DateTime, embeddable). Such a wrapper was left shared
between the original and the clone, with its parent still pointing at the
original — so setting the property on the clone mutated the original.

Initialize the property and guard on is_object() instead, so any
initialized wrapper object is cloned and re-parented regardless of value.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

fix: keep current entity in HasOne::getEntitiesForPersistence()

$this->tracked is a list, so `$this->tracked + [$entity]` dropped $entity
whenever the relationship had changed at least once (both arrays use key
0 and + keeps the left side). On the non-main side of a 1:1, replacing a
persisted entity with a new one then silently excluded the new entity
from the cascade, resulting in a lost insert.

Use array_merge() so the current entity is always kept.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

fix: resolve entity getters/setters per concrete entity in MetadataParser

classPropertiesCache keyed parsed PropertyMetadata by defining
class/trait but baked in the first parsed concrete entity's method list
for getter/setter resolution, and shared those instances across siblings.
Two entities sharing an abstract base/trait therefore contaminated each
other: parse order decided whether one crashed calling a missing getter
or the other's getter was silently ignored.

Stop resolving getters/setters at parse time. Clone each cached property
per concrete entity (createEntityProperty) and resolve getters/setters
against that entity's methods. PropertyMetadata::__clone resets the
lazily-built wrapper prototype so each clone rebuilds its own.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>