### PR TITLE
add #[\NoDiscard] to read-only API

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -9,7 +9,15 @@ In Orm, we use a coding standard which assumes that
 - `find*` methods return an `ICollection` instance.
 </div>
 
-Collection itself is **immutable**; all methods that modify the collection return a new `ICollection` instance. Collection provides the following methods:
+Collection itself is **immutable**; all methods that modify the collection return a new `ICollection` instance. To make ignoring such a returned collection obvious, the `ICollection` methods are marked with PHP 8.5's `#[\NoDiscard]` attribute; on PHP 8.5 and newer, PHP reports a warning when their return value is not used.
+
+```php
+$books = $orm->books->findAll();
+$books->orderBy('title'); // wrong: the returned collection is discarded
+$books = $books->orderBy('title'); // correct
+```
+
+Collection provides the following methods:
 
 | Function                                                         | Description                                                                                                                    |
 |------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/migrate_6.0.md
+++ b/docs/migrate_6.0.md
@@ -74,3 +74,15 @@
   ```
 
   The `configureModel`/`configureRepository`/`configureMapper` hooks run when the respective service is instantiated; the `configureEntityMetadata`/`configureEntityPropertyMetadata` hooks run at compile time while entity metadata is parsed (before it is cached).
+
+- **`#[\NoDiscard]` on read-only API** - methods that only compute and return a value are marked with PHP 8.5's `#[\NoDiscard]` attribute; most notably the whole `ICollection` API, but also `IRepository`, `IModel`, `IMapper`, `IEntity` and relationship getters.
+
+  On PHP 8.5 and newer, PHP reports a warning when such a call's return value is thrown away. This catches the classic mistake of treating the immutable collection as a mutable one:
+
+  ```php
+  $books = $orm->books->findAll();
+  $books->orderBy('title'); // warning: the returned collection is discarded
+  $books = $books->orderBy('title'); // correct
+  ```
+
+  Intentionally discarding the value is done by the `(void)` cast. On PHP 8.1-8.4 the attribute has no effect.

--- a/src/Bridges/NetteDI/DiRepositoryLoader.php
+++ b/src/Bridges/NetteDI/DiRepositoryLoader.php
@@ -31,6 +31,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function hasRepository(string $className): bool
 	{
 		return isset($this->repositoryClassNameToDiNameMap[$className]);
@@ -38,6 +39,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function hasRepositoryByName(string $name): bool
 	{
 		return isset($this->repositoryNameToDiNameMap[$name]);
@@ -45,6 +47,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepository(string $className): IRepository|null
 	{
 		return $this->container->getService($this->repositoryClassNameToDiNameMap[$className]);
@@ -52,6 +55,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepositoryByName(string $name): IRepository|null
 	{
 		return $this->container->getService($this->repositoryNameToDiNameMap[$name]);
@@ -64,6 +68,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 	 * @return class-string<IRepository<E>>|null
 	 */
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepositoryClassNameForEntity(string $entityClassName): string|null
 	{
 		/** @var class-string<IRepository<E>>|null */
@@ -72,6 +77,7 @@ class DiRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function getInitializedRepositories(): array
 	{
 		$repositories = [];

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -67,24 +67,28 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity
 	{
 		return $this->findBy($conds)->fetch();
 	}
 
 
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity
 	{
 		return $this->findBy($conds)->fetchChecked();
 	}
 
 
+	#[\NoDiscard]
 	public function getById($id): ?IEntity
 	{
 		return $this->getBy(['id' => $id]);
 	}
 
 
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity
 	{
 		$entity = $this->getById($id);
@@ -95,6 +99,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function findBy(array $conds): ICollection
 	{
 		$collection = clone $this;
@@ -103,6 +108,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function orderBy($expression, string $direction = self::ASC): ICollection
 	{
 		$collection = clone $this;
@@ -117,6 +123,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function resetOrderBy(): ICollection
 	{
 		$collection = clone $this;
@@ -125,6 +132,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function limitBy(int $limit, int|null $offset = null): ICollection
 	{
 		$collection = clone $this;
@@ -133,6 +141,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetch(): ?IEntity
 	{
 		if ($this->fetchIterator === null) {
@@ -149,6 +158,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchChecked(): IEntity
 	{
 		$entity = $this->fetch();
@@ -159,12 +169,14 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchAll(): array
 	{
 		return iterator_to_array($this->getIterator(), preserve_keys: false);
 	}
 
 
+	#[\NoDiscard]
 	public function fetchPairs(string|null $key = null, string|null $value = null): array
 	{
 		return FetchPairsHelper::process($this->getIterator(), $key, $value);
@@ -186,6 +198,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	/**
 	 * @return Iterator<int, E>
 	 */
+	#[\NoDiscard]
 	public function getIterator(): Iterator
 	{
 		if ($this->relationshipParent !== null && $this->relationshipMapper !== null) {
@@ -212,6 +225,7 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function count(): int
 	{
 		$iterator = $this->getIterator();
@@ -220,12 +234,14 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function countStored(): int
 	{
 		return $this->count();
 	}
 
 
+	#[\NoDiscard]
 	public function toMemoryCollection(): MemoryCollection
 	{
 		return clone $this;
@@ -239,12 +255,14 @@ class ArrayCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function getRelationshipMapper(): ?IRelationshipMapper
 	{
 		return $this->relationshipMapper;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function setRelationshipParent(IEntity $parent): ICollection
 	{
 		$collection = clone $this;

--- a/src/Collection/DbalCollection.php
+++ b/src/Collection/DbalCollection.php
@@ -70,24 +70,28 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity
 	{
 		return $this->findBy($conds)->fetch();
 	}
 
 
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity
 	{
 		return $this->findBy($conds)->fetchChecked();
 	}
 
 
+	#[\NoDiscard]
 	public function getById($id): ?IEntity
 	{
 		return $this->getBy(['id' => $id]);
 	}
 
 
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity
 	{
 		$entity = $this->getById($id);
@@ -98,6 +102,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function findBy(array $conds): ICollection
 	{
 		$collection = clone $this;
@@ -124,6 +129,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function orderBy($expression, string $direction = ICollection::ASC): ICollection
 	{
 		$collection = clone $this;
@@ -141,6 +147,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function resetOrderBy(): ICollection
 	{
 		$collection = clone $this;
@@ -152,6 +159,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function limitBy(int $limit, int|null $offset = null): ICollection
 	{
 		$collection = clone $this;
@@ -160,6 +168,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetch(): ?IEntity
 	{
 		if ($this->fetchIterator === null) {
@@ -176,6 +185,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchChecked(): IEntity
 	{
 		$entity = $this->fetch();
@@ -186,12 +196,14 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchAll(): array
 	{
 		return iterator_to_array($this->getIterator(), preserve_keys: false);
 	}
 
 
+	#[\NoDiscard]
 	public function fetchPairs(string|null $key = null, string|null $value = null): array
 	{
 		return FetchPairsHelper::process($this->getIterator(), $key, $value);
@@ -213,6 +225,7 @@ class DbalCollection implements ICollection
 	/**
 	 * @return Iterator<int, E>
 	 */
+	#[\NoDiscard]
 	public function getIterator(): Iterator
 	{
 		if ($this->relationshipParent !== null && $this->relationshipMapper !== null) {
@@ -240,12 +253,14 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function count(): int
 	{
 		return iterator_count($this->getIterator());
 	}
 
 
+	#[\NoDiscard]
 	public function countStored(): int
 	{
 		if ($this->relationshipParent !== null && $this->relationshipMapper !== null) {
@@ -256,6 +271,7 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function toMemoryCollection(): MemoryCollection
 	{
 		$collection = clone $this;
@@ -271,12 +287,14 @@ class DbalCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function getRelationshipMapper(): ?IRelationshipMapper
 	{
 		return $this->relationshipMapper;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function setRelationshipParent(IEntity $parent): ICollection
 	{
 		$collection = clone $this;
@@ -308,6 +326,7 @@ class DbalCollection implements ICollection
 	 * next fetch reflects the changes. Internal callers intentionally read {@see $queryBuilder} directly to avoid
 	 * invalidating an in-progress iteration.
 	 */
+	#[\NoDiscard]
 	public function getQueryBuilder(): QueryBuilder
 	{
 		$this->result = null;

--- a/src/Collection/EmptyCollection.php
+++ b/src/Collection/EmptyCollection.php
@@ -20,78 +20,91 @@ final class EmptyCollection implements ICollection, MemoryCollection
 	private ?IRelationshipMapper $relationshipMapper = null;
 
 
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity
 	{
 		return null;
 	}
 
 
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity
 	{
 		throw new NoResultException();
 	}
 
 
+	#[\NoDiscard]
 	public function getById($id): ?IEntity
 	{
 		return null;
 	}
 
 
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity
 	{
 		throw new NoResultException();
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function findBy(array $conds): ICollection
 	{
 		return clone $this;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function orderBy($expression, string $direction = self::ASC): ICollection
 	{
 		return clone $this;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function resetOrderBy(): ICollection
 	{
 		return clone $this;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function limitBy(int $limit, int|null $offset = null): ICollection
 	{
 		return clone $this;
 	}
 
 
+	#[\NoDiscard]
 	public function fetch(): ?IEntity
 	{
 		return null;
 	}
 
 
+	#[\NoDiscard]
 	public function fetchChecked(): IEntity
 	{
 		throw new NoResultException();
 	}
 
 
+	#[\NoDiscard]
 	public function fetchAll(): array
 	{
 		return [];
 	}
 
 
+	#[\NoDiscard]
 	public function fetchPairs(string|null $key = null, string|null $value = null): array
 	{
 		return [];
 	}
 
 
+	#[\NoDiscard]
 	public function getIterator(): Iterator
 	{
 		return new EmptyIterator();
@@ -105,30 +118,35 @@ final class EmptyCollection implements ICollection, MemoryCollection
 	}
 
 
+	#[\NoDiscard]
 	public function getRelationshipMapper(): ?IRelationshipMapper
 	{
 		return $this->relationshipMapper;
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function setRelationshipParent(IEntity $parent): ICollection
 	{
 		return clone $this;
 	}
 
 
+	#[\NoDiscard]
 	public function countStored(): int
 	{
 		return 0;
 	}
 
 
+	#[\NoDiscard]
 	public function count(): int
 	{
 		return 0;
 	}
 
 
+	#[\NoDiscard]
 	public function toMemoryCollection(): MemoryCollection
 	{
 		return clone $this;

--- a/src/Collection/HasManyCollection.php
+++ b/src/Collection/HasManyCollection.php
@@ -57,24 +57,28 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity
 	{
 		return $this->findBy($conds)->fetch();
 	}
 
 
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity
 	{
 		return $this->findBy($conds)->fetchChecked();
 	}
 
 
+	#[\NoDiscard]
 	public function getById($id): ?IEntity
 	{
 		return $this->getBy(['id' => $id]);
 	}
 
 
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity
 	{
 		$entity = $this->getById($id);
@@ -85,6 +89,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function findBy(array $conds): ICollection
 	{
 		$collection = clone $this;
@@ -94,6 +99,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function orderBy($expression, string $direction = self::ASC): ICollection
 	{
 		$collection = clone $this;
@@ -103,6 +109,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function resetOrderBy(): ICollection
 	{
 		$collection = clone $this;
@@ -112,6 +119,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function limitBy(int $limit, int|null $offset = null): ICollection
 	{
 		$collection = clone $this;
@@ -121,6 +129,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetch(): ?IEntity
 	{
 		if ($this->fetchIterator === null) {
@@ -137,6 +146,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchChecked(): IEntity
 	{
 		$entity = $this->fetch();
@@ -147,18 +157,21 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function fetchAll(): array
 	{
 		return iterator_to_array($this->getIterator(), preserve_keys: false);
 	}
 
 
+	#[\NoDiscard]
 	public function fetchPairs(string|null $key = null, string|null $value = null): array
 	{
 		return FetchPairsHelper::process($this->getIterator(), $key, $value);
 	}
 
 
+	#[\NoDiscard]
 	public function getIterator(): Iterator
 	{
 		[$toAdd, $toRemove] = ($this->diffCallback)();
@@ -188,12 +201,14 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function count(): int
 	{
 		return iterator_count($this->getIterator());
 	}
 
 
+	#[\NoDiscard]
 	public function countStored(): int
 	{
 		[$toAdd, $toRemove] = ($this->diffCallback)();
@@ -204,6 +219,7 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function toMemoryCollection(): MemoryCollection
 	{
 		$collection = clone $this;
@@ -220,12 +236,14 @@ class HasManyCollection implements ICollection
 	}
 
 
+	#[\NoDiscard]
 	public function getRelationshipMapper(): ?IRelationshipMapper
 	{
 		return $this->storageCollection->getRelationshipMapper();
 	}
 
 
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function setRelationshipParent(IEntity $parent): ICollection
 	{
 		$collection = clone $this;

--- a/src/Collection/ICollection.php
+++ b/src/Collection/ICollection.php
@@ -46,6 +46,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @param array<string, mixed>|array<mixed> $conds
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity;
 
 
@@ -58,6 +59,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @throws NoResultException
 	 * @return E
 	 */
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity;
 
 
@@ -66,6 +68,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @param mixed $id
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function getById($id): ?IEntity;
 
 
@@ -75,6 +78,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @throws NoResultException
 	 * @return E
 	 */
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity;
 
 
@@ -111,6 +115,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @param array<mixed> $conds
 	 * @return static
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function findBy(array $conds): ICollection;
 
 
@@ -144,6 +149,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @param string $direction the sorting direction self::ASC or self::DESC, etc.
 	 * @return static
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function orderBy($expression, string $direction = self::ASC): ICollection;
 
 
@@ -151,6 +157,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Resets collection ordering.
 	 * @return static
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function resetOrderBy(): ICollection;
 
 
@@ -158,6 +165,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Limits number of rows.
 	 * @return static
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function limitBy(int $limit, int|null $offset = null): ICollection;
 
 
@@ -165,6 +173,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Fetches the first row.
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function fetch(): ?IEntity;
 
 
@@ -173,6 +182,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @throws NoResultException
 	 * @return E
 	 */
+	#[\NoDiscard]
 	public function fetchChecked(): IEntity;
 
 
@@ -180,6 +190,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Fetches all records.
 	 * @return list<E>
 	 */
+	#[\NoDiscard]
 	public function fetchAll(): array;
 
 
@@ -189,12 +200,14 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @param string|null $value value
 	 * @return array<int|string, mixed>
 	 */
+	#[\NoDiscard]
 	public function fetchPairs(string|null $key = null, string|null $value = null): array;
 
 
 	/**
 	 * @return Iterator<int, E>
 	 */
+	#[\NoDiscard]
 	public function getIterator(): Iterator;
 
 
@@ -202,6 +215,7 @@ interface ICollection extends IteratorAggregate, Countable
 	 * Fetches requested data and returns MemoryCollection instance with the fetched entities.
 	 * @return MemoryCollection<E>
 	 */
+	#[\NoDiscard]
 	public function toMemoryCollection(): MemoryCollection;
 
 
@@ -216,6 +230,7 @@ interface ICollection extends IteratorAggregate, Countable
 	/**
 	 * @internal
 	 */
+	#[\NoDiscard]
 	public function getRelationshipMapper(): ?IRelationshipMapper;
 
 
@@ -223,12 +238,14 @@ interface ICollection extends IteratorAggregate, Countable
 	 * @return static
 	 * @internal
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function setRelationshipParent(IEntity $parent): ICollection;
 
 
 	/**
 	 * Counts collection entities without fetching them from storage.
 	 */
+	#[\NoDiscard]
 	public function countStored(): int;
 
 

--- a/src/Collection/MutableArrayCollection.php
+++ b/src/Collection/MutableArrayCollection.php
@@ -14,6 +14,7 @@ class MutableArrayCollection extends ArrayCollection
 	 * @param list<E> $data
 	 * @return static
 	 */
+	#[\NoDiscard('Method returns a new collection instance, the original collection is not modified.')]
 	public function withData(array $data): ICollection
 	{
 		$collection = clone $this;

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -42,6 +42,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function getRepository(): IRepository
 	{
 		if ($this->repository === null) {
@@ -52,18 +53,21 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function isAttached(): bool
 	{
 		return $this->repository !== null;
 	}
 
 
+	#[\NoDiscard]
 	public function getMetadata(): EntityMetadata
 	{
 		return $this->metadata;
 	}
 
 
+	#[\NoDiscard]
 	public function isModified(string|null $name = null): bool
 	{
 		if ($name === null) {
@@ -81,12 +85,14 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function isPersisted(): bool
 	{
 		return $this->persistedId !== null;
 	}
 
 
+	#[\NoDiscard]
 	public function getPersistedId()
 	{
 		return $this->persistedId;
@@ -137,6 +143,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function &getRawValue(string $name)
 	{
 		$property = $this->metadata->getProperty($name);
@@ -161,6 +168,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function getProperty(string $name): IProperty
 	{
 		$propertyMetadata = $this->metadata->getProperty($name);
@@ -176,6 +184,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function getRawProperty(string $name)
 	{
 		$propertyMetadata = $this->metadata->getProperty($name);
@@ -187,6 +196,7 @@ abstract class AbstractEntity implements IEntity
 	}
 
 
+	#[\NoDiscard]
 	public function getRawValues(bool $modifiedOnly = false): array
 	{
 		$out = [];

--- a/src/Entity/Embeddable/Embeddable.php
+++ b/src/Entity/Embeddable/Embeddable.php
@@ -50,6 +50,7 @@ abstract class Embeddable implements IEmbeddable
 	}
 
 
+	#[\NoDiscard]
 	public function getRawValue(): array
 	{
 		$out = [];

--- a/src/Entity/Embeddable/IEmbeddable.php
+++ b/src/Entity/Embeddable/IEmbeddable.php
@@ -15,6 +15,7 @@ interface IEmbeddable
 	/**
 	 * Returns true if property has a not null value.
 	 */
+	#[\NoDiscard]
 	public function hasValue(string $name): bool;
 
 
@@ -22,6 +23,7 @@ interface IEmbeddable
 	 * Returns value.
 	 * @return mixed
 	 */
+	#[\NoDiscard]
 	public function &getValue(string $name);
 
 
@@ -38,6 +40,7 @@ interface IEmbeddable
 	 * @return array<string, mixed>
 	 * @internal
 	 */
+	#[\NoDiscard]
 	public function getRawValue(): array;
 
 

--- a/src/Entity/IEntity.php
+++ b/src/Entity/IEntity.php
@@ -12,6 +12,7 @@ interface IEntity
 	/**
 	 * @return IRepository<IEntity>
 	 */
+	#[\NoDiscard]
 	public function getRepository(): IRepository;
 
 
@@ -35,12 +36,14 @@ interface IEntity
 	 * Returns value.
 	 * @return mixed
 	 */
+	#[\NoDiscard]
 	public function &getValue(string $name);
 
 
 	/**
 	 * Returns true if property has a value (not null).
 	 */
+	#[\NoDiscard]
 	public function hasValue(string $name): bool;
 
 
@@ -56,12 +59,14 @@ interface IEntity
 	 * Raw value is normalized value which is suitable unique identification and storing.
 	 * @return mixed
 	 */
+	#[\NoDiscard]
 	public function &getRawValue(string $name);
 
 
 	/**
 	 * Returns property wrapper.
 	 */
+	#[\NoDiscard]
 	public function getProperty(string $name): IProperty;
 
 
@@ -69,6 +74,7 @@ interface IEntity
 	 * Returns property raw contents: IProperty if initialized, a raw value otherwise.
 	 * @return mixed
 	 */
+	#[\NoDiscard]
 	public function getRawProperty(string $name);
 
 
@@ -81,18 +87,21 @@ interface IEntity
 	 * @return array<string, mixed>
 	 * @internal
 	 */
+	#[\NoDiscard]
 	public function getRawValues(bool $modifiedOnly = false): array;
 
 
 	/**
 	 * Returns entity metadata.
 	 */
+	#[\NoDiscard]
 	public function getMetadata(): EntityMetadata;
 
 
 	/**
 	 * Returns true if the entity is modified or the column $name is modified.
 	 */
+	#[\NoDiscard]
 	public function isModified(string|null $name = null): bool;
 
 
@@ -105,6 +114,7 @@ interface IEntity
 	/**
 	 * Returns true if entity is persisted.
 	 */
+	#[\NoDiscard]
 	public function isPersisted(): bool;
 
 
@@ -112,12 +122,14 @@ interface IEntity
 	 * Returns persisted primary value.
 	 * @return mixed
 	 */
+	#[\NoDiscard]
 	public function getPersistedId();
 
 
 	/**
 	 * Returns true if entity is attached to its repository.
 	 */
+	#[\NoDiscard]
 	public function isAttached(): bool;
 
 

--- a/src/Entity/ImmutableDataTrait.php
+++ b/src/Entity/ImmutableDataTrait.php
@@ -23,6 +23,7 @@ trait ImmutableDataTrait
 	private array $validated = [];
 
 
+	#[\NoDiscard]
 	public function &getValue(string $name)
 	{
 		$property = $this->metadata->getProperty($name);
@@ -30,6 +31,7 @@ trait ImmutableDataTrait
 	}
 
 
+	#[\NoDiscard]
 	public function hasValue(string $name): bool
 	{
 		$property = $this->metadata->getProperty($name);

--- a/src/Mapper/Dbal/DbalMapper.php
+++ b/src/Mapper/Dbal/DbalMapper.php
@@ -78,6 +78,7 @@ abstract class DbalMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function getRepository(): IRepository
 	{
 		if ($this->repository === null) {
@@ -89,6 +90,7 @@ abstract class DbalMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function findAll(): ICollection
 	{
 		/** @var ICollection<E> $collection */
@@ -138,6 +140,7 @@ abstract class DbalMapper implements IMapper
 	 * @param QueryBuilder|list<array<string, mixed>>|Result $data
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function toCollection($data): ICollection
 	{
 		if ($data instanceof QueryBuilder) {
@@ -228,6 +231,7 @@ abstract class DbalMapper implements IMapper
 
 	// == Relationship mappers =========================================================================================
 
+	#[\NoDiscard]
 	public function createCollectionManyHasOne(PropertyMetadata $metadata): ICollection
 	{
 		return $this->findAll()->setRelationshipMapper(
@@ -236,6 +240,7 @@ abstract class DbalMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionOneHasOne(PropertyMetadata $metadata): ICollection
 	{
 		assert($metadata->relationship !== null);
@@ -247,6 +252,7 @@ abstract class DbalMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionManyHasMany(IMapper $sourceMapper, PropertyMetadata $metadata): ICollection
 	{
 		return $this->findAll()->setRelationshipMapper(
@@ -255,6 +261,7 @@ abstract class DbalMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionOneHasMany(PropertyMetadata $metadata): ICollection
 	{
 		return $this->findAll()->setRelationshipMapper(

--- a/src/Mapper/IMapper.php
+++ b/src/Mapper/IMapper.php
@@ -18,6 +18,7 @@ interface IMapper
 	 * Returns all entities.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function findAll(): ICollection;
 
 
@@ -25,6 +26,7 @@ interface IMapper
 	 * Creates collection with HasOne mapper.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function createCollectionManyHasOne(PropertyMetadata $metadata): ICollection;
 
 
@@ -32,6 +34,7 @@ interface IMapper
 	 * Creates a collection with OneHasOneDirected mapper.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function createCollectionOneHasOne(PropertyMetadata $metadata): ICollection;
 
 
@@ -40,6 +43,7 @@ interface IMapper
 	 * @param IMapper<IEntity> $sourceMapper
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function createCollectionManyHasMany(IMapper $sourceMapper, PropertyMetadata $metadata): ICollection;
 
 
@@ -47,6 +51,7 @@ interface IMapper
 	 * Creates collection with OneHasMany mapper.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function createCollectionOneHasMany(PropertyMetadata $metadata): ICollection;
 
 
@@ -59,6 +64,7 @@ interface IMapper
 	/**
 	 * @return IRepository<E>
 	 */
+	#[\NoDiscard]
 	public function getRepository(): IRepository;
 
 

--- a/src/Mapper/Memory/ArrayMapper.php
+++ b/src/Mapper/Memory/ArrayMapper.php
@@ -52,6 +52,7 @@ abstract class ArrayMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function getRepository(): IRepository
 	{
 		if ($this->repository === null) {
@@ -63,6 +64,7 @@ abstract class ArrayMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function findAll(): ICollection
 	{
 		return new ArrayCollection($this->getData(), $this->getRepository());
@@ -73,12 +75,14 @@ abstract class ArrayMapper implements IMapper
 	 * @param list<E> $data
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function toCollection(array $data): ICollection
 	{
 		return new ArrayCollection($data, $this->getRepository());
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionManyHasOne(PropertyMetadata $metadata): ICollection
 	{
 		$collection = $this->findAll();
@@ -87,6 +91,7 @@ abstract class ArrayMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionOneHasOne(PropertyMetadata $metadata): ICollection
 	{
 		assert($metadata->relationship !== null);
@@ -100,6 +105,7 @@ abstract class ArrayMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionManyHasMany(IMapper $sourceMapper, PropertyMetadata $metadata): ICollection
 	{
 		assert($sourceMapper instanceof ArrayMapper);
@@ -109,6 +115,7 @@ abstract class ArrayMapper implements IMapper
 	}
 
 
+	#[\NoDiscard]
 	public function createCollectionOneHasMany(PropertyMetadata $metadata): ICollection
 	{
 		$collection = $this->findAll();

--- a/src/Model/IModel.php
+++ b/src/Model/IModel.php
@@ -12,6 +12,7 @@ interface IModel
 	/**
 	 * Returns true if repository with name is attached to model.
 	 */
+	#[\NoDiscard]
 	public function hasRepositoryByName(string $name): bool;
 
 
@@ -19,6 +20,7 @@ interface IModel
 	 * Returns repository by repository name.
 	 * @return IRepository<*>
 	 */
+	#[\NoDiscard]
 	public function getRepositoryByName(string $name): IRepository;
 
 
@@ -27,6 +29,7 @@ interface IModel
 	 * @template T of IRepository
 	 * @param class-string<T> $className
 	 */
+	#[\NoDiscard]
 	public function hasRepository(string $className): bool;
 
 
@@ -37,6 +40,7 @@ interface IModel
 	 * @param class-string<T> $className
 	 * @return T
 	 */
+	#[\NoDiscard]
 	public function getRepository(string $className): IRepository;
 
 
@@ -46,12 +50,14 @@ interface IModel
 	 * @param E|class-string<E> $entity
 	 * @return IRepository<E>
 	 */
+	#[\NoDiscard]
 	public function getRepositoryForEntity($entity): IRepository;
 
 
 	/**
 	 * Returns entity metadata storage.
 	 */
+	#[\NoDiscard]
 	public function getMetadataStorage(): MetadataStorage;
 
 

--- a/src/Model/IRepositoryLoader.php
+++ b/src/Model/IRepositoryLoader.php
@@ -13,6 +13,7 @@ interface IRepositoryLoader
 	 * Returns true if repository exists.
 	 * @param class-string<IRepository<IEntity>> $className
 	 */
+	#[\NoDiscard]
 	public function hasRepository(string $className): bool;
 
 
@@ -20,6 +21,7 @@ interface IRepositoryLoader
 	 * Returns true if repository exists with the simple $name.
 	 * Repository may not be registered with a name. Class name is implicitly always present, though.
 	 */
+	#[\NoDiscard]
 	public function hasRepositoryByName(string $name): bool;
 
 	/**
@@ -29,6 +31,7 @@ interface IRepositoryLoader
 	 * @param class-string<T> $className
 	 * @return T|null
 	 */
+	#[\NoDiscard]
 	public function getRepository(string $className): IRepository|null;
 
 	/**
@@ -37,6 +40,7 @@ interface IRepositoryLoader
 	 *
 	 * @return IRepository<*>|null
 	 */
+	#[\NoDiscard]
 	public function getRepositoryByName(string $name): IRepository|null;
 
 
@@ -46,6 +50,7 @@ interface IRepositoryLoader
 	 * @param class-string<E> $entityClassName
 	 * @return class-string<IRepository<E>>|null
 	 */
+	#[\NoDiscard]
 	public function getRepositoryClassNameForEntity(string $entityClassName): string|null;
 
 
@@ -53,5 +58,6 @@ interface IRepositoryLoader
 	 * Returns list of loaded (already initialized) repositories.
 	 * @return list<IRepository<*>>
 	 */
+	#[\NoDiscard]
 	public function getInitializedRepositories(): array;
 }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -32,12 +32,14 @@ class Model implements IModel
 	}
 
 
+	#[\NoDiscard]
 	public function hasRepositoryByName(string $name): bool
 	{
 		return $this->repositoryLoader->hasRepositoryByName($name);
 	}
 
 
+	#[\NoDiscard]
 	public function getRepositoryByName(string $name): IRepository
 	{
 		return $this->repositoryLoader->getRepositoryByName($name)
@@ -45,12 +47,14 @@ class Model implements IModel
 	}
 
 
+	#[\NoDiscard]
 	public function hasRepository(string $className): bool
 	{
 		return $this->repositoryLoader->hasRepository($className);
 	}
 
 
+	#[\NoDiscard]
 	public function getRepository(string $className): IRepository
 	{
 		return $this->repositoryLoader->getRepository($className)
@@ -58,6 +62,7 @@ class Model implements IModel
 	}
 
 
+	#[\NoDiscard]
 	public function getRepositoryForEntity($entity): IRepository
 	{
 		$entityClassName = is_string($entity) ? $entity : get_class($entity);
@@ -67,6 +72,7 @@ class Model implements IModel
 	}
 
 
+	#[\NoDiscard]
 	public function getMetadataStorage(): MetadataStorage
 	{
 		return $this->metadataStorage;

--- a/src/Model/SimpleRepositoryLoader.php
+++ b/src/Model/SimpleRepositoryLoader.php
@@ -42,6 +42,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function hasRepository(string $className): bool
 	{
 		return isset($this->repositories[$className]);
@@ -49,6 +50,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function hasRepositoryByName(string $name): bool
 	{
 		return isset($this->nameToClassNameMap[$name]);
@@ -61,6 +63,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 	 * @return T|null
 	 */
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepository(string $className): IRepository|null
 	{
 		/** @var T|null */
@@ -69,6 +72,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepositoryByName(string $name): IRepository|null
 	{
 		$className = $this->nameToClassNameMap[$name] ?? null;
@@ -82,6 +86,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 	 * @return class-string<IRepository<E>>|null
 	 */
 	#[\Override]
+	#[\NoDiscard]
 	public function getRepositoryClassNameForEntity(string $entityClassName): string|null
 	{
 		/** @var class-string<IRepository<E>>|null */
@@ -90,6 +95,7 @@ class SimpleRepositoryLoader implements IRepositoryLoader
 
 
 	#[\Override]
+	#[\NoDiscard]
 	public function getInitializedRepositories(): array
 	{
 		return array_values($this->repositories);

--- a/src/Relationships/HasMany.php
+++ b/src/Relationships/HasMany.php
@@ -191,6 +191,7 @@ abstract class HasMany implements IRelationshipCollection
 	}
 
 
+	#[\NoDiscard]
 	public function has($entity): bool
 	{
 		$entity = $this->createEntity($entity, need: false, attach: false);
@@ -253,18 +254,21 @@ abstract class HasMany implements IRelationshipCollection
 	}
 
 
+	#[\NoDiscard]
 	public function toCollection(): ICollection
 	{
 		return clone $this->getCollection(forceNew: true);
 	}
 
 
+	#[\NoDiscard]
 	public function count(): int
 	{
 		return iterator_count($this->getIterator());
 	}
 
 
+	#[\NoDiscard]
 	public function countStored(): int
 	{
 		return $this->getIterator()->countStored();
@@ -274,18 +278,21 @@ abstract class HasMany implements IRelationshipCollection
 	/**
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function getIterator(): ICollection
 	{
 		return $this->getCollection();
 	}
 
 
+	#[\NoDiscard]
 	public function isLoaded(): bool
 	{
 		return $this->collection !== null || count($this->toAdd) > 0 || count($this->toRemove) > 0 || count($this->tracked) > 0;
 	}
 
 
+	#[\NoDiscard]
 	public function isModified(): bool
 	{
 		return $this->isModified;

--- a/src/Relationships/HasOne.php
+++ b/src/Relationships/HasOne.php
@@ -81,9 +81,9 @@ abstract class HasOne implements IRelationshipContainer
 	public function onEntityRepositoryAttach(IEntity $entity): void
 	{
 		if (!$this->isValueValidated) {
-			$this->getEntity();
-			if ($this->value instanceof IEntity) {
-				$this->attachIfPossible($this->value);
+			$value = $this->getEntity();
+			if ($value !== null) {
+				$this->attachIfPossible($value);
 			}
 		}
 	}
@@ -131,6 +131,7 @@ abstract class HasOne implements IRelationshipContainer
 	}
 
 
+	#[\NoDiscard]
 	public function isLoaded(): bool
 	{
 		return $this->value instanceof IEntity;
@@ -182,6 +183,7 @@ abstract class HasOne implements IRelationshipContainer
 	}
 
 
+	#[\NoDiscard]
 	public function getEntity(): ?IEntity
 	{
 		$value = $this->getValue();
@@ -195,6 +197,7 @@ abstract class HasOne implements IRelationshipContainer
 	}
 
 
+	#[\NoDiscard]
 	public function isModified(): bool
 	{
 		return $this->isModified;

--- a/src/Relationships/IRelationshipCollection.php
+++ b/src/Relationships/IRelationshipCollection.php
@@ -53,6 +53,7 @@ interface IRelationshipCollection extends IPropertyContainer, IEntityAwareProper
 	/**
 	 * @param E|string|int $entity
 	 */
+	#[\NoDiscard]
 	public function has($entity): bool;
 
 
@@ -60,24 +61,28 @@ interface IRelationshipCollection extends IPropertyContainer, IEntityAwareProper
 	 * Returns collection of all entity.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function toCollection(): ICollection;
 
 
 	/**
 	 * Returns true if collection was loaded.
 	 */
+	#[\NoDiscard]
 	public function isLoaded(): bool;
 
 
 	/**
 	 * Returns true if relationship is modified.
 	 */
+	#[\NoDiscard]
 	public function isModified(): bool;
 
 
 	/**
 	 * Counts collection entities without fetching them from storage.
 	 */
+	#[\NoDiscard]
 	public function countStored(): int;
 
 

--- a/src/Relationships/IRelationshipContainer.php
+++ b/src/Relationships/IRelationshipContainer.php
@@ -17,6 +17,7 @@ interface IRelationshipContainer extends IPropertyContainer, IEntityAwarePropert
 	/**
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function getEntity(): ?IEntity;
 
 
@@ -24,12 +25,14 @@ interface IRelationshipContainer extends IPropertyContainer, IEntityAwarePropert
 	 * Returns true if container was loaded, i.e. the relationship contains an entity in contrast to its primary
 	 * key only.
 	 */
+	#[\NoDiscard]
 	public function isLoaded(): bool;
 
 
 	/**
 	 * Returns true if relationship is modified.
 	 */
+	#[\NoDiscard]
 	public function isModified(): bool;
 
 

--- a/src/Repository/IRepository.php
+++ b/src/Repository/IRepository.php
@@ -25,6 +25,7 @@ use Nextras\Orm\Model\IModel;
  */
 interface IRepository
 {
+	#[\NoDiscard]
 	public function getModel(): IModel;
 
 
@@ -34,6 +35,7 @@ interface IRepository
 	/**
 	 * @return IMapper<E>
 	 */
+	#[\NoDiscard]
 	public function getMapper(): IMapper;
 
 
@@ -63,6 +65,7 @@ interface IRepository
 	 * Returns possible entity class names for current repository.
 	 * @return list<class-string<IEntity>>
 	 */
+	#[\NoDiscard]
 	public static function getEntityClassNames(): array;
 
 
@@ -71,6 +74,7 @@ interface IRepository
 	 * @template F of E
 	 * @param class-string<F>|null $entityClass for STI (must extend a base class)
 	 */
+	#[\NoDiscard]
 	public function getEntityMetadata(string|null $entityClass = null): EntityMetadata;
 
 
@@ -79,6 +83,7 @@ interface IRepository
 	 * @param array<string, mixed> $data
 	 * @return class-string<E>
 	 */
+	#[\NoDiscard]
 	public function getEntityClassName(array $data): string;
 
 
@@ -90,6 +95,7 @@ interface IRepository
 	 * @param array<string, mixed>|array<mixed> $conds
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity;
 
 
@@ -102,6 +108,7 @@ interface IRepository
 	 * @throws NoResultException
 	 * @return E
 	 */
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity;
 
 
@@ -110,6 +117,7 @@ interface IRepository
 	 * @param mixed $id
 	 * @return E|null
 	 */
+	#[\NoDiscard]
 	public function getById($id): ?IEntity;
 
 
@@ -119,6 +127,7 @@ interface IRepository
 	 * @throws NoResultException
 	 * @return E
 	 */
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity;
 
 
@@ -126,6 +135,7 @@ interface IRepository
 	 * Returns new collection with all entities.
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function findAll(): ICollection;
 
 
@@ -162,6 +172,7 @@ interface IRepository
 	 * @param array<string, mixed>|array<int|string, mixed>|list<mixed> $conds
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function findBy(array $conds): ICollection;
 
 
@@ -170,12 +181,14 @@ interface IRepository
 	 * @param list<mixed> $ids
 	 * @return ICollection<E>
 	 */
+	#[\NoDiscard]
 	public function findByIds(array $ids): ICollection;
 
 
 	/**
 	 * Returns a collection function instance. May be cached.
 	 */
+	#[\NoDiscard]
 	public function getCollectionFunction(string $name): CollectionFunction;
 
 

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -122,6 +122,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getModel(): IModel
 	{
 		if ($this->model === null) {
@@ -142,18 +143,21 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getMapper(): IMapper
 	{
 		return $this->mapper;
 	}
 
 
+	#[\NoDiscard]
 	public function getBy(array $conds): ?IEntity
 	{
 		return $this->findAll()->getBy($conds);
 	}
 
 
+	#[\NoDiscard]
 	public function getByChecked(array $conds): IEntity
 	{
 		$entity = $this->getBy($conds);
@@ -164,6 +168,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getById($id): ?IEntity
 	{
 		if ($id === null) {
@@ -186,6 +191,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getByIdChecked($id): IEntity
 	{
 		$entity = $this->getById($id);
@@ -196,18 +202,21 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function findAll(): ICollection
 	{
 		return $this->mapper->findAll();
 	}
 
 
+	#[\NoDiscard]
 	public function findBy(array $conds): ICollection
 	{
 		return $this->findAll()->findBy($conds);
 	}
 
 
+	#[\NoDiscard]
 	public function findByIds(array $ids): ICollection
 	{
 		$entities = [];
@@ -230,6 +239,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getCollectionFunction(string $name): CollectionFunction
 	{
 		if (!isset($this->collectionFunctions[$name])) {
@@ -301,6 +311,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getEntityMetadata(string|null $entityClass = null): EntityMetadata
 	{
 		$classNames = static::getEntityClassNames();
@@ -311,6 +322,7 @@ abstract class Repository implements IRepository
 	}
 
 
+	#[\NoDiscard]
 	public function getEntityClassName(array $data): string
 	{
 		if ($this->entityClassName === null) {

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -471,7 +471,8 @@ abstract class Repository implements IRepository
 		}
 		if (count($ids) > 0) {
 			sort($ids); // make ids sorted deterministically
-			$this->findByIds($ids)->fetchAll();
+			// the fetch itself refreshes the entities in the identity map
+			$refreshedEntities = $this->findByIds($ids)->fetchAll();
 		}
 		foreach ($entities as $entity) {
 			if (!$this->identityMap->isMarkedForRefresh($entity)) {

--- a/tests/cases/integration/Collection/collection.embeddables.phpt
+++ b/tests/cases/integration/Collection/collection.embeddables.phpt
@@ -69,7 +69,7 @@ class CollectionEmbeddablesTest extends DataTestCase
 	public function testInvalidExpression(): void
 	{
 		Assert::throws(function (): void {
-			$this->orm->authors->findBy(['books->price' => 20])->fetchAll();
+			$authors = $this->orm->authors->findBy(['books->price' => 20])->fetchAll();
 		}, InvalidArgumentException::class, 'Property expression \'books->price\' does not fetch specific property.');
 	}
 }

--- a/tests/cases/integration/Collection/collection.phpt
+++ b/tests/cases/integration/Collection/collection.phpt
@@ -294,11 +294,11 @@ class CollectionTest extends DataTestCase
 	public function testNonNullable(): void
 	{
 		Assert::throws(function (): void {
-			$this->orm->books->findAll()->getByIdChecked(923);
+			$book = $this->orm->books->findAll()->getByIdChecked(923);
 		}, NoResultException::class);
 
 		Assert::throws(function (): void {
-			$this->orm->books->findAll()->getByChecked(['id' => 923]);
+			$book = $this->orm->books->findAll()->getByChecked(['id' => 923]);
 		}, NoResultException::class);
 
 		Assert::type(Book::class, $this->orm->books->findAll()->getByIdChecked(1));
@@ -377,7 +377,7 @@ class CollectionTest extends DataTestCase
 	public function testFetchChecked(): void
 	{
 		Assert::throws(function (): void {
-			$this->orm->books->findBy(['id' => 923])->fetchChecked();
+			$book = $this->orm->books->findBy(['id' => 923])->fetchChecked();
 		}, NoResultException::class);
 
 		$book = $this->orm->books->findAll()->fetchChecked();

--- a/tests/cases/integration/Entity/entity.compositePK.phpt
+++ b/tests/cases/integration/Entity/entity.compositePK.phpt
@@ -117,7 +117,7 @@ class EntityCompositePKTest extends DataTestCase
 	public function testGetByIdWronglyUsedWithIndexedKeys(): void
 	{
 		Assert::throws(function (): void {
-			$this->orm->tagFollowers->getById(['author' => 1, 'tag' => 3]);
+			$tagFollower = $this->orm->tagFollowers->getById(['author' => 1, 'tag' => 3]);
 		}, InvalidArgumentException::class, 'Composite primary value has to be passed as a list, without array keys.');
 	}
 

--- a/tests/cases/integration/Entity/entity.nullValidation.phpt
+++ b/tests/cases/integration/Entity/entity.nullValidation.phpt
@@ -47,12 +47,12 @@ class EntityNullValidationTest extends TestCase
 	{
 		Assert::throws(function (): void {
 			$book = new Book();
-			$book->getValue('title');
+			$title = $book->getValue('title');
 		}, InvalidStateException::class, 'Property NextrasTests\Orm\Book::$title is not set.');
 
 		Assert::throws(function (): void {
 			$book = new Book();
-			$book->getValue('author');
+			$author = $book->getValue('author');
 		}, NullValueException::class, 'Property NextrasTests\Orm\Book::$author is not nullable.');
 	}
 
@@ -72,7 +72,7 @@ class EntityNullValidationTest extends TestCase
 		Assert::false($book->hasValue('author'));
 
 		Assert::throws(function () use ($book): void {
-			$book->getValue('author');
+			$author = $book->getValue('author');
 		}, NullValueException::class, 'Property NextrasTests\Orm\Book::$author is not nullable.');
 	}
 }

--- a/tests/cases/integration/Entity/entity.nullValidation.phpt
+++ b/tests/cases/integration/Entity/entity.nullValidation.phpt
@@ -69,7 +69,7 @@ class EntityNullValidationTest extends TestCase
 	public function testValidationOnGetter(): void
 	{
 		$book = new Book();
-		$book->hasValue('author');
+		Assert::false($book->hasValue('author'));
 
 		Assert::throws(function () use ($book): void {
 			$book->getValue('author');

--- a/tests/cases/integration/Relationships/relationships.manyHasMany.collection.phpt
+++ b/tests/cases/integration/Relationships/relationships.manyHasMany.collection.phpt
@@ -292,7 +292,7 @@ class RelationshipsManyHasManyCollectionTest extends DataTestCase
 			$this->tags->add($this->createTag());
 			Assert::count(1, $this->tags->getEntitiesForPersistence());
 
-			$this->tags->toCollection()->fetchAll(); // SELECT JOIN + SELECT TAG
+			$tags = $this->tags->toCollection()->fetchAll(); // SELECT JOIN + SELECT TAG
 			Assert::count(3, $this->tags->getEntitiesForPersistence());
 		});
 
@@ -307,7 +307,7 @@ class RelationshipsManyHasManyCollectionTest extends DataTestCase
 		$queries = $this->getQueries(function (): void {
 			Assert::count(0, $this->tags->getEntitiesForPersistence());
 
-			$this->tags->toCollection()->orderBy('id')->limitBy(1)->fetchAll(); // SELECT JOIN + SELECT TAG
+			$tags = $this->tags->toCollection()->orderBy('id')->limitBy(1)->fetchAll(); // SELECT JOIN + SELECT TAG
 			// one book from releationship
 			Assert::count(1, $this->tags->getEntitiesForPersistence());
 		});

--- a/tests/cases/integration/Relationships/relationships.oneHasMany.collection.phpt
+++ b/tests/cases/integration/Relationships/relationships.oneHasMany.collection.phpt
@@ -302,7 +302,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 			$this->books->add($this->createBook());
 			Assert::count(1, $this->books->getEntitiesForPersistence());
 
-			$this->books->toCollection()->fetchAll(); // SELECT
+			$books = $this->books->toCollection()->fetchAll(); // SELECT
 			Assert::count(3, $this->books->getEntitiesForPersistence());
 		});
 
@@ -317,7 +317,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 		$queries = $this->getQueries(function (): void {
 			Assert::count(0, $this->books->getEntitiesForPersistence());
 
-			$this->books->toCollection()->limitBy(1)->fetchAll();
+			$books = $this->books->toCollection()->limitBy(1)->fetchAll();
 			if ($this->section === Helper::SECTION_ARRAY) {
 				// array collection loads the book relationship during filtering the related books
 				Assert::count(2, $this->books->getEntitiesForPersistence());
@@ -387,7 +387,7 @@ class RelationshipsOneHasManyCollectionTest extends DataTestCase
 			Assert::count(0, $this->books->getEntitiesForPersistence());
 
 			$book2 = $this->orm->books->getByIdChecked(2); // SELECT
-			$book2->getValue('author'); // SELECT
+			$author = $book2->getValue('author'); // SELECT
 			Assert::count(1, $this->books->getEntitiesForPersistence());
 
 			// 4 SELECTS: all rest relationships (books_x_tags, tags, books.next_part, publisher)

--- a/tests/cases/integration/Repository/repository.phpt
+++ b/tests/cases/integration/Repository/repository.phpt
@@ -22,11 +22,11 @@ class RepositoryTest extends DataTestCase
 	public function testNonNullable(): void
 	{
 		Assert::throws(function (): void {
-			$this->orm->books->findAll()->getByIdChecked(923);
+			$book = $this->orm->books->findAll()->getByIdChecked(923);
 		}, NoResultException::class);
 
 		Assert::throws(function (): void {
-			$this->orm->books->findAll()->getByChecked(['id' => 923]);
+			$book = $this->orm->books->findAll()->getByChecked(['id' => 923]);
 		}, NoResultException::class);
 
 		Assert::type(Book::class, $this->orm->books->findAll()->getByIdChecked(1));

--- a/tests/cases/unit/Entity/AbstractEntity.properties.phpt
+++ b/tests/cases/unit/Entity/AbstractEntity.properties.phpt
@@ -22,12 +22,12 @@ class AbstractEntityPropertiesTest extends TestCase
 	{
 		Assert::throws(function (): void {
 			$book = new Book();
-			$book->getValue('blabla');
+			$value = $book->getValue('blabla');
 		}, InvalidArgumentException::class, 'Undefined property NextrasTests\Orm\Book::$blabla.');
 
 		Assert::throws(function (): void {
 			$book = new Book();
-			$book->getValue('title2');
+			$value = $book->getValue('title2');
 		}, InvalidArgumentException::class, 'Undefined property NextrasTests\Orm\Book::$title2, did you mean $title?');
 	}
 }

--- a/tests/cases/unit/Entity/AbstractEntity.repository.phpt
+++ b/tests/cases/unit/Entity/AbstractEntity.repository.phpt
@@ -47,7 +47,7 @@ class AbstractEntityRepositoryTest extends TestCase
 		$entity->onAfterRemove();
 		Assert::false($entity->isAttached());
 		Assert::throws(function () use ($entity): void {
-			$entity->getRepository();
+			$repository = $entity->getRepository();
 		}, InvalidStateException::class);
 	}
 

--- a/tests/cases/unit/Mapper/Dbal/DbalMapperTest.phpt
+++ b/tests/cases/unit/Mapper/Dbal/DbalMapperTest.phpt
@@ -106,7 +106,7 @@ class DbalMapperTest extends TestCase
 		Assert::throws(function () use ($mapper): void {
 			/** @noinspection PhpParamsInspection */
 			// @phpstan-ignore-next-line
-			$mapper->toCollection(new ArrayCollection([], $this->orm->authors));
+			$collection = $mapper->toCollection(new ArrayCollection([], $this->orm->authors));
 		}, InvalidArgumentException::class);
 	}
 


### PR DESCRIPTION
Closes #805.

Marks the methods that only compute and return a value with PHP 8.5's `#[\NoDiscard]` attribute, so that PHP reports a warning when their return value is thrown away.

Most importantly the whole `ICollection` API — discarding the result of `findBy()` / `orderBy()` / `limitBy()` / `resetOrderBy()` silently does nothing, because the collection is immutable:

```php
$books = $orm->books->findAll();
$books->orderBy('title'); // warning on PHP 8.5+: the returned collection is discarded
$books = $books->orderBy('title'); // correct
```

Those four methods (plus `setRelationshipParent()`, `MutableArrayCollection::withData()`) carry an explanatory message; the remaining ones use the bare attribute.

### Covered

- `ICollection` + `ArrayCollection`, `MutableArrayCollection`, `DbalCollection`, `EmptyCollection`, `HasManyCollection`
- `IRelationshipCollection` / `IRelationshipContainer` + `HasMany`, `HasOne`
- `IRepository` + `Repository`
- `IModel` + `Model`, `IRepositoryLoader` + `SimpleRepositoryLoader`, `DiRepositoryLoader`
- `IMapper` + `DbalMapper`, `ArrayMapper`
- `IEntity` + `AbstractEntity`, `ImmutableDataTrait`, `IEmbeddable` + `Embeddable`

### Notes

- The attribute is **not inherited** by overriding methods — it is evaluated on the declaration that is actually called. It is therefore declared both on the interfaces (documentation value) and on their implementations (where it takes effect).
- Methods called for their side effect are intentionally left out: `persist*()`, `remove*()`, `flush()`, `setValue()`, `add()` / `remove()` / `set()` / `removeAll()` on relationships, the `do*()` / `on*()` hooks, and `ICollection::setRelationshipMapper()` — unlike `setRelationshipParent()`, it mutates the collection in place and returns `$this`, and is called for the side effect in `ArrayMapper`.
- Two existing call sites intentionally discarded a now-marked result and were rewritten to use it: `HasOne::onEntityRepositoryAttach()` and `EntityNullValidationTest::testValidationOnGetter()` (`Assert::false()` on the `hasValue()` result).
- On PHP 8.1–8.4 the attribute has no effect, so this is not a BC break; it is documented in `docs/collection.md` and `docs/migrate_6.0.md`.

### Verified

- PHPStan level 8 (bleeding edge, with the project's extensions): no errors. PHPStan 2.2.8 resolves `\NoDiscard` from its stubs, so it does not report `attribute.notFound` when analysing on PHP < 8.5.
- Full test suite with the `array` storage: 321 tests, OK (PHP 8.4 — a PHP 8.5 runtime was not reachable from this environment, so the CI matrix's 8.5 job is the real check for the warnings).
- Audited `src/` and `tests/` with a token-based scan for statement-position calls to every newly marked method; the only remaining hits are `Nextras\Dbal\QueryBuilder::orderBy()` calls, which are unrelated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXp4U8hXf74A5egcMgdG7b)_